### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tetherto/ai-runtime-bk-models


### PR DESCRIPTION
This PR adds a CODEOWNERS file assigning ownership to @tetherto/ai-runtime-bk-models.