### PR TITLE
DEVOPS-916: Add ai-runtime-merge to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @tetherto/ai-runtime-bk-addons @tetherto/ai-runtime-bk-models @tetherto/ai-runtime-bk-core
+* @tetherto/ai-runtime-bk-addons @tetherto/ai-runtime-bk-models @tetherto/ai-runtime-bk-core @tetherto/ai-runtime-merge


### PR DESCRIPTION
Appends @tetherto/ai-runtime-merge to the global (*) CODEOWNERS rule.

- If CODEOWNERS exists: append to the existing `* ...` line (no overwrite).
- If not: create `.github/CODEOWNERS` with `* @tetherto/ai-runtime-merge`.
