### PR TITLE
QVAC-18966 [TTS GGML] Fix CPU regression

### DIFF
--- a/tts-cpp/src/supertonic_internal.h
+++ b/tts-cpp/src/supertonic_internal.h
@@ -697,70 +697,152 @@ inline void make_rope_cos_sin_tables(const float * theta,
 // n_heads, L]` — the natural layout the scalar `apply_rope`
 // reference indexes into (`data[t*H*D + h*D + d]`).  Every actual
 // call site in the vector estimator produces Q/K via
-// `dense_matmul_time_ggml`, whose output is a 2D packed tensor
-// with `ne=[H*D, L]` (channel-major along axis 0, time along
-// axis 1).  `apply_rope_to_packed_qk` adapts between the two
-// layouts so the graph builders can bake the rotation in-place
-// without reshaping the rest of the QKV plumbing:
+// `dense_matmul_time_ggml`, whose output is a 2D tensor with
+// `ne=[L, HD]` — axis 0 = L (time, fastest along natural strides
+// `nb=[elem, L*elem]`) and axis 1 = HD = n_heads * head_dim
+// (packed channels h*D+d, slowest).  In flat memory the element
+// (t, c) sits at byte offset `(t + c*L)*elem` — i.e. **channel-
+// major-flat** (`data[t + c*L]`), which is the bit-exact transpose
+// of the time-major-flat layout the scalar `apply_rope` reference
+// indexes through (`data[t*H*D + h*D + d]`).
 //
-//   - Re-views the packed tensor as `[head_dim, n_heads, L]` via
-//     a zero-cost stride trick (`nb[0]=elem, nb[1]=D*4, nb[2]=H*D*4`)
-//     — the memory pattern `data[t*H*D + h*D + d]` is preserved
-//     bit-exactly.
-//   - Materialises a contiguous copy (`ggml_cont`) so the
+// QVAC-18966 — same-shape matmul on every backend: confirmed by
+// inspection of the CPU custom-op fast path (`ggml_custom_4d(F32,
+// x->ne[0] /* = L */, w->ne[0] /* = OC */, …)` → `[L, OC]`) and
+// the `conv1d_f32(K=1)` fallback (`ggml_reshape_3d(result,
+// im2col->ne[1] /* = L */, kernel->ne[2] /* = OC */, …)` → also
+// `[L, OC]`).  Both code paths produce the same ne contract — so
+// this helper's adapter has to bridge the **matmul-output**
+// channel-major-flat layout onto `apply_rope_in_graph`'s natural-
+// strides `[D, H, L]` contract.
+//
+// History note: the original (PR #16 follow-up #5) version of
+// this helper assumed `q->ne[0] = HD` and `q->ne[1] = L` — i.e.,
+// the transpose of what the matmul actually produces.  That
+// older contract crashed at the defensive assertion below on
+// every real synth (the moment a GGUF carrying `vector_rope_theta`
+// enabled the in-graph rotation path).  The CPU unit test that
+// landed alongside `apply_rope_to_packed_qk` hand-built Q under
+// the `[HD, L]` assumption, so the failure mode was invisible to
+// CI.  GPU backends (Metal / CUDA / Vulkan / OpenCL) silently
+// dispatched a transposed view through the rotation, masking the
+// shape problem until a CPU `--n-gpu-layers 0` synth hit the
+// assert.  See QVAC-18966.  `test_supertonic_rope_packed_qk.cpp`
+// now reproduces the **production** matmul layout and pins both
+// the input and output shape contracts.
+//
+// Pipeline (production layout):
+//   - Step 1: `ggml_cont(ggml_transpose(q))` — view-swap axes
+//     0/1 (zero-cost stride flip) then materialise to natural
+//     strides.  Result has ne=[HD, L] with **time-major-flat**
+//     memory layout (`data[c + t*HD]`).  This is the SAME layout
+//     `q_tc_in` (`ggml_new_tensor_2d(A, L)` in
+//     `vector_text_attention_cache`) expects for the
+//     `ggml_backend_tensor_copy` device→device blit at the GPU-
+//     bridge dispatch site.
+//   - Step 2: Re-view the packed tensor as `[head_dim, n_heads,
+//     L]` via the zero-cost stride trick `nb[0]=elem,
+//     nb[1]=D*elem, nb[2]=HD*elem` — element (d, h, l) lands at
+//     offset `d + h*D + l*HD` (elem units), identical to the
+//     post-transpose layout's element (col=h*D+d, row=l) at
+//     `col + row*HD`.
+//   - Step 3: Materialise a contiguous `[D, H, L]` copy so the
 //     downstream `ggml_concat` inside `apply_rope_in_graph` sees
 //     monotonically-increasing strides.
-//   - Calls `apply_rope_in_graph(ctx, x_dhl, cos, sin)`.
-//   - Reshapes the rotated `[D, H, L]` result back to `[H*D, L]`
-//     so call sites can keep their existing `ggml_set_output` +
-//     `tensor_to_time_channel` plumbing unchanged.
+//   - Step 4: `apply_rope_in_graph(ctx, x_dhl, cos, sin)`.
+//   - Step 5: Reshape the rotated `[D, H, L]` result back to
+//     `[HD, L]` — same memory, different ne labels.  Bytes are
+//     in time-major-flat layout `data[c + t*HD]`, byte-for-byte
+//     identical to scalar `apply_rope`'s output and to what
+//     `q_tc_in` expects.
 //
-// Cost vs. the current host-side `apply_rope`:
+// Call-site impact for the bytes-out contract:
+//   - GPU bridge (`run_text_attention_cache_gpu`): unchanged.
+//     `ggml_backend_tensor_copy(q_rope, q_tc_in)` already passes
+//     `ggml_nbytes(src) == ggml_nbytes(dst)` (same nelements)
+//     and now also matches the destination's memory layout
+//     bit-for-bit.
+//   - Legacy host bridge: `tensor_to_time_channel(q_rope)` was
+//     designed for the (incorrectly-shaped) old contract and
+//     would now read the transpose-of-the-transpose if called
+//     unchanged.  Use `tensor_raw_f32(q_rope)` instead — the
+//     bytes are already time-major-flat (matches scalar
+//     `apply_rope`'s output buffer contract), and uploading
+//     them via `ggml_backend_tensor_set` to `q_tc_in` lands the
+//     same bytes the GPU-bridge `ggml_backend_tensor_copy`
+//     would.  The four production call sites in
+//     `supertonic_vector_estimator.cpp` are updated in lock-step
+//     with this helper.
+//   - Trace mode: the `PUSH_GGML_TRACE` entries push a
+//     `std::vector<float>` shaped as `{L, HD}` (i.e., flat
+//     `out[t*HD + c]` — scalar `apply_rope`'s native indexing).
+//     `tensor_raw_f32(q_rope)` returns exactly that layout, so
+//     trace parity vs. the scalar harness is preserved without
+//     any further re-pack.
+//
+// Cost vs. the pre-fix (broken) helper:
+//   - Adds one `ggml_cont` per site (the head-of-pipeline
+//     transpose).  On CPU it is a single memcpy of `L * HD * 4`
+//     bytes; on GPU backends it is one shader dispatch per
+//     cache build.  The cache is built ONCE and reused across
+//     all 5 denoise steps, so the cost is fully amortised.
 //   - Eliminates 40 CPU rotations / synth (~50 µs each ≈ 2 ms
 //     wall-time on the default 5-step × 4-RoPE-site schedule).
-//   - Trades for one extra `ggml_cont` per site (small kernel
-//     on GPU; ~0).  No new ops beyond `view + cont + reshape +
-//     ggml_concat` chain already proven by the inner helper.
 //
-// Universally-supported ops only: `ggml_view_3d`, `ggml_cont`,
-// `ggml_reshape_2d` + everything `apply_rope_in_graph` uses.
-// Green on baseline upstream OpenCL.
+// Universally-supported ops only: `ggml_transpose`, `ggml_cont`,
+// `ggml_view_3d`, `ggml_reshape_2d` + everything
+// `apply_rope_in_graph` uses.  Green on baseline upstream OpenCL.
 //
 // Parity-tested in `test_supertonic_rope_packed_qk.cpp` against
 // the scalar `apply_rope` on the two hot vector-estimator shapes
-// (`q_len=20 × H=4 × D=64`, `kv_len=32 × H=4 × D=64`) and a
-// degenerate `L=1` trip-wire.  Tolerance `1e-4` absolute.
+// (`q_len=20 × H=4 × D=64`, `kv_len=32 × H=4 × D=64`), a
+// degenerate `L=1` trip-wire, and an explicit output-shape
+// contract check that pins `ne[0]=HD, ne[1]=L`.  Tolerance
+// `1e-4` absolute.
 inline ggml_tensor * apply_rope_to_packed_qk(ggml_context * ctx,
                                               ggml_tensor * q,
                                               ggml_tensor * cos_table,
                                               ggml_tensor * sin_table,
                                               int n_heads,
                                               int head_dim) {
-    const int64_t L  = q->ne[1];
-    const int64_t HD = q->ne[0];
+    // Step 1 — transpose `ne=[L, HD]` (matmul-output contract,
+    // channel-major-flat memory) into `ne=[HD, L]` with natural
+    // time-major-flat memory.  `ggml_transpose` is a view-only
+    // axis swap (nb[0] ↔ nb[1]); `ggml_cont` materialises the
+    // natural strides `nb=[elem, HD*elem]`.  This is the SAME
+    // memory layout the downstream `q_tc_in` consumes — the
+    // helper's output then plumbs unchanged into both the GPU-
+    // bridge `ggml_backend_tensor_copy` and the legacy host-
+    // bridge `tensor_raw_f32` paths.
+    ggml_tensor * q_packed = ggml_cont(ctx, ggml_transpose(ctx, q));
+
+    const int64_t L  = q_packed->ne[1];
+    const int64_t HD = q_packed->ne[0];
     (void) HD; // assertion-only; compiler may drop in NDEBUG.
     GGML_ASSERT(HD == (int64_t) n_heads * head_dim);
-    // q has natural strides for ne=[HD, L]: nb[0]=elem_size,
-    // nb[1]=HD*elem_size.  A view with ne=[D, H, L] sharing the
-    // same memory needs nb=[elem, D*elem, HD*elem]; element
-    // (d, h, l) lands at offset `d + h*D + l*HD` in 4-byte units
-    // — identical memory pattern to the original packed layout's
-    // element (col=h*D+d, row=l) at `col + row*HD` = `h*D + d + l*HD`.
-    ggml_tensor * q_dhl_view = ggml_view_3d(ctx, q,
+
+    // Step 2 — re-view the `[HD, L]` packed tensor as `[D, H, L]`
+    // via the zero-cost stride trick.  q_packed has natural
+    // strides nb=[elem, HD*elem]; the view nb=[elem, D*elem,
+    // HD*elem] gives element (d, h, l) at offset `d + h*D + l*HD`
+    // (elem units) — bit-identical to (col=h*D+d, row=l) at
+    // `col + row*HD` in the original packed layout.
+    ggml_tensor * q_dhl_view = ggml_view_3d(ctx, q_packed,
         head_dim, n_heads, L,
         /*nb1=*/(size_t) head_dim * sizeof(float),
         /*nb2=*/(size_t) n_heads * head_dim * sizeof(float),
         /*offset=*/0);
-    // Materialise a contiguous [D, H, L] copy so the downstream
-    // concat / repeat ops in `apply_rope_in_graph` see natural
-    // strides (`nb=[elem, D*elem, D*H*elem]`).  The view above is
-    // legal but non-natural (nb[1]<nb[2] with a `D*elem`/`H*D*elem`
+    // Step 3 — materialise a contiguous [D, H, L] copy so the
+    // downstream `ggml_concat` / `ggml_repeat` ops in
+    // `apply_rope_in_graph` see natural strides
+    // (`nb=[elem, D*elem, D*H*elem]`).  The view above is legal
+    // but non-natural (`nb[1]<nb[2]` with a `D*elem`/`H*D*elem`
     // ratio that some backends' op implementations refuse).
     ggml_tensor * q_dhl = ggml_cont(ctx, q_dhl_view);
     ggml_tensor * q_rot = apply_rope_in_graph(ctx, q_dhl, cos_table, sin_table);
-    // Reshape back to the packed [HD, L] shape; same memory,
-    // different ne labels — downstream consumers (flash-attn cache
-    // upload buffers, trace download) see the original layout.
+    // Step 4 — reshape back to the packed `[HD, L]` shape; same
+    // memory, different ne labels.  Bytes are in time-major-flat
+    // layout `data[c + t*HD]`.
     return ggml_reshape_2d(ctx, q_rot, (int64_t) n_heads * head_dim, L);
 }
 

--- a/tts-cpp/src/supertonic_vector_estimator.cpp
+++ b/tts-cpp/src/supertonic_vector_estimator.cpp
@@ -1358,9 +1358,31 @@ void build_group_graph_cache(vector_group_graph_cache & cache,
     ggml_tensor * k = dense_matmul_time_pretransposed_ggml(cache.ctx, model, cache.text_in,
         require_source_tensor(model, k_matmul_source),
         require_source_tensor(model, attn_prefix + "W_key.linear.bias"));
-    ggml_tensor * v = dense_matmul_time_pretransposed_ggml(cache.ctx, model, cache.text_in,
+    // QVAC-18966 — pack V into the layout the downstream
+    // `run_text_attention_cache_gpu` consumes via
+    // `ggml_backend_tensor_copy(v_src, v_tc_in)`.  `v_tc_in` is
+    // `ggml_new_tensor_2d(F32, A=HD, kv_len)` → ne=[HD, kv_len]
+    // with natural strides nb=[elem, HD*elem] (time-major-flat
+    // memory `data[c + t*HD]`).  `dense_matmul_time_(pre)ggml`
+    // produces ne=[L_kv, HD] with channel-major-flat memory
+    // (`data[t + c*L_kv]`) — the byte-for-byte transpose of what
+    // the bridge expects.  `ggml_cont(ggml_transpose(...))` flips
+    // the strides + materialises a contiguous fresh tensor with
+    // the right layout.  Mirrors the head-of-pipeline transpose
+    // inside `apply_rope_to_packed_qk` so Q-rope / K-rope / V all
+    // land in `q_tc_in` / `k_tc_in` / `v_tc_in` bit-exactly.  See
+    // the header doc on `apply_rope_to_packed_qk` in
+    // `supertonic_internal.h` for the full layout reasoning.
+    //
+    // Legacy host bridge: `tensor_raw_f32(v_gpu)` downloads the
+    // post-transpose bytes (time-major-flat `out[t*HD + c]`) —
+    // bit-identical to what scalar `apply_rope`'s reference loop
+    // produces and what every legacy `push_trace`-consuming
+    // harness expects (callers updated in lock-step).
+    ggml_tensor * v_matmul = dense_matmul_time_pretransposed_ggml(cache.ctx, model, cache.text_in,
         require_source_tensor(model, v_matmul_source),
         require_source_tensor(model, attn_prefix + "W_value.linear.bias"));
+    ggml_tensor * v = ggml_cont(cache.ctx, ggml_transpose(cache.ctx, v_matmul));
     ggml_set_name(q, q_name.c_str()); ggml_set_output(q); ggml_build_forward_expand(cache.gf, q);
     ggml_set_name(k, k_name.c_str()); ggml_set_output(k); ggml_build_forward_expand(cache.gf, k);
     ggml_set_name(v, v_name.c_str()); ggml_set_output(v); ggml_build_forward_expand(cache.gf, v);
@@ -1525,16 +1547,41 @@ vector_group_graph_result run_group_graph_cache(vector_group_graph_cache & cache
         // `push_trace` block below and the call-site
         // `PUSH_GGML_TRACE({"ve_g*_attn_v", …})` push.  The legacy
         // host-RoPE fallback consumes them directly.
+        //
+        // Q / K matmul outputs are UNCHANGED ne=[L, HD] / ne=[text_
+        // len, HD] channel-major-flat memory, so `tensor_to_time_
+        // channel` is the right call (decodes col=c, row=t at
+        // `c*L + t` into out[t*HD + c]).
         out.q = tensor_to_time_channel(ggml_graph_get_tensor(cache.gf, q_name.c_str()));
         out.k = tensor_to_time_channel(ggml_graph_get_tensor(cache.gf, k_name.c_str()));
-        out.v = tensor_to_time_channel(ggml_graph_get_tensor(cache.gf, v_name.c_str()));
+        // QVAC-18966 — V is now graph-packed to ne=[HD, text_len]
+        // time-major-flat by the head-of-V transpose in
+        // `build_group_graph_cache`.  `tensor_raw_f32` downloads
+        // the bytes in the layout scalar `apply_rope` /
+        // `flash_attention_qkv` host references expect
+        // (`v[t*HD + c]`).  `tensor_to_time_channel` would now
+        // mis-interpret the swapped ne (reading HD as L_var and
+        // L as C_var) and silently feed wrong-orientation V into
+        // the attention.  See the header doc on
+        // `apply_rope_to_packed_qk` in `supertonic_internal.h`.
+        out.v = tensor_raw_f32(ggml_graph_get_tensor(cache.gf, v_name.c_str()));
     }
     if (trace && cache.apply_rope) {
         // Trace-only extra downloads — post-RoPE Q/K mirrors the
         // call site's `PUSH_GGML_TRACE({"ve_g*_attn_q_rope", …})`.
-        out.q_rope = tensor_to_time_channel(
+        //
+        // QVAC-18966 — post-fix layout contract:
+        // `apply_rope_to_packed_qk` now produces ne=[HD, L] with
+        // time-major-flat memory (`data[c + t*HD]`).  Those bytes
+        // ARE the scalar `apply_rope`'s native flat layout
+        // (`out[t*HD + c]`), so `tensor_raw_f32` downloads them
+        // directly — no transpose needed.  `tensor_to_time_channel`
+        // would mis-interpret the new ne shape and produce the
+        // transpose of the transpose.  See the header doc on
+        // `apply_rope_to_packed_qk` in `supertonic_internal.h`.
+        out.q_rope = tensor_raw_f32(
             ggml_graph_get_tensor(cache.gf, cache.q_rope_name.c_str()));
-        out.k_rope = tensor_to_time_channel(
+        out.k_rope = tensor_raw_f32(
             ggml_graph_get_tensor(cache.gf, cache.k_rope_name.c_str()));
     }
     if (trace) {
@@ -2973,9 +3020,22 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
             ggml_set_name(k_t, "ve_attn0_k");
             ggml_set_output(k_t);
             ggml_build_forward_expand(front_cache.gf, k_t);
-            ggml_tensor * v_t = dense_matmul_time_ggml(front_cache.ctx, front_cache.text_in_t,
+            // QVAC-18966 — pack V into the layout
+            // `run_text_attention_cache_gpu` consumes via
+            // `ggml_backend_tensor_copy(v_src, v_tc_in)`.  See the
+            // identical transpose in `build_group_graph_cache` +
+            // the header doc on `apply_rope_to_packed_qk` in
+            // `supertonic_internal.h`.  Matmul output is ne=[L_kv,
+            // HD] channel-major-flat; v_tc_in expects ne=[HD,
+            // L_kv] time-major-flat.  Legacy host bridge
+            // downloads `ve_attn0_v` via `tensor_raw_f32` to get
+            // bytes in the time-major-flat shape scalar
+            // `apply_rope` / `flash_attention_qkv` references.
+            ggml_tensor * v_matmul = dense_matmul_time_ggml(front_cache.ctx, front_cache.text_in_t,
                 require_source_tensor(model, "vector_estimator:onnx::MatMul_3103"),
                 require_source_tensor(model, "vector_estimator:tts.ttl.vector_field.main_blocks.3.attn.W_value.linear.bias"));
+            ggml_tensor * v_t = ggml_cont(front_cache.ctx,
+                ggml_transpose(front_cache.ctx, v_matmul));
             ggml_set_name(v_t, "ve_attn0_v");
             ggml_set_output(v_t);
             ggml_build_forward_expand(front_cache.gf, v_t);
@@ -3098,7 +3158,22 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
         PUSH_GGML_TRACE({"ve_time_add0", {L, C}, tensor_to_time_channel(ggml_graph_get_tensor(gf, "ve_time_add0"))});
         std::vector<float> block2_ggml = tensor_to_time_channel(ggml_graph_get_tensor(gf, "ve_block2_convnext0"));
         PUSH_GGML_TRACE({"ve_block2_convnext0", {L, C}, block2_ggml});
-        std::vector<float> v_out = tensor_to_time_channel(ggml_graph_get_tensor(gf, "ve_attn0_v"));
+        // QVAC-18966 — `ve_attn0_v` is now `ggml_cont(ggml_
+        // transpose(...))` of the matmul output (ne=[HD, text_len]
+        // time-major-flat memory).  `tensor_raw_f32` downloads
+        // the bytes in the layout scalar `apply_rope` /
+        // `flash_attention_qkv` host references expect
+        // (`v[t*HD + c]`) — bit-identical to what
+        // `run_text_attention_cache`'s host upload writes into
+        // `v_tc_in` (`ggml_new_tensor_2d(F32, HD, kv_len)` natural
+        // strides nb=[elem, HD*elem]).  Using
+        // `tensor_to_time_channel` here would mis-interpret the
+        // swapped ne and silently feed wrong-orientation V into
+        // the attention.  Q/K matmul outputs are UNCHANGED ne=[L,
+        // HD] channel-major-flat so `tensor_to_time_channel` stays
+        // the right call for them.  See the header doc on
+        // `apply_rope_to_packed_qk` in `supertonic_internal.h`.
+        std::vector<float> v_out = tensor_raw_f32(ggml_graph_get_tensor(gf, "ve_attn0_v"));
         // F23 — when the front-block graph has the in-graph RoPE
         // wired in (model carries `vector_rope_theta`), feed
         // `run_text_attention_cache` the already-rotated Q/K from
@@ -3117,8 +3192,19 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
         const bool front_in_graph_rope =
             ggml_graph_get_tensor(gf, "ve_attn0_q_rope") != nullptr;
         if (front_in_graph_rope) {
-            q_rotated = tensor_to_time_channel(ggml_graph_get_tensor(gf, "ve_attn0_q_rope"));
-            k_rotated = tensor_to_time_channel(ggml_graph_get_tensor(gf, "ve_attn0_k_rope"));
+            // QVAC-18966 — post-fix layout contract:
+            // `apply_rope_to_packed_qk` produces ne=[HD, L] with
+            // time-major-flat memory (`data[c + t*HD]`).  Those
+            // bytes ARE scalar `apply_rope`'s native flat layout
+            // (`out[t*HD + c]`), so `tensor_raw_f32` downloads
+            // them directly — no transpose needed.  Using
+            // `tensor_to_time_channel` would mis-interpret the
+            // swapped ne shape and produce the transpose of the
+            // transpose, silently feeding wrong-orientation Q / K
+            // into the attention.  See the header doc on
+            // `apply_rope_to_packed_qk` in `supertonic_internal.h`.
+            q_rotated = tensor_raw_f32(ggml_graph_get_tensor(gf, "ve_attn0_q_rope"));
+            k_rotated = tensor_raw_f32(ggml_graph_get_tensor(gf, "ve_attn0_k_rope"));
         } else {
             // Legacy path: GGUF lacks vector_rope_theta-typed wiring.
             // Materialise Q/K host-side, rotate, then forward.

--- a/tts-cpp/test/test_supertonic_rope_packed_qk.cpp
+++ b/tts-cpp/test/test_supertonic_rope_packed_qk.cpp
@@ -1,41 +1,54 @@
-// TDD harness for the audit follow-up #5 packed-QK RoPE helper
-// (F23 = F20 integration: bake apply_rope into the Q/K-producing
-// group / front-block graph so the host doesn't run apply_rope
-// between the QKV download and the flash-attention upload).
+// QVAC-18966 — CPU regression fix for `apply_rope_to_packed_qk`.
 //
 // Background
 // ----------
-// `apply_rope_in_graph` (landed in PR #4) operates on a
-// `ne=[head_dim, n_heads, L]` tensor — the natural layout the
-// scalar `apply_rope` indexes into.  But every actual call site
-// in the vector estimator produces Q/K via
-// `dense_matmul_time_ggml`, whose output is a packed 2D tensor
-// with `ne=[H*D, L]` (`H*D` = the attention `A` dimension =
-// `n_heads * head_dim`, packed channel-major along axis 0).
+// `apply_rope_to_packed_qk` is the layout adapter between the
+// natural `ne=[head_dim, n_heads, L]` contract of
+// `apply_rope_in_graph` (PR #4) and the **production** call sites'
+// Q/K-producing matmul output.  Both PR #16 ("RoPE in-graph
+// integration F23") and the front-block GPU bridge plumb the
+// result of this helper through to
+// `vector_text_attention_cache::q_tc_in` via either
+// `ggml_backend_tensor_copy` (GPU bridge, production) or
+// `ggml_backend_tensor_set` from a host vector (legacy bridge,
+// trace-mode + non-RoPE GGUFs).
 //
-// `apply_rope_to_packed_qk` is a thin wrapper that re-views the
-// packed tensor as `[head_dim, n_heads, L]` (zero-cost view via
-// stride trick), materialises a contiguous copy so downstream
-// `ggml_concat` is happy, calls `apply_rope_in_graph`, and
-// reshapes the result back to the original `[H*D, L]` packed
-// shape.  No new ops introduced — just a packing-layout adapter.
+// The original test (PR #16, follow-up #5) built Q under a
+// `ne=[H*D, L]` "channel-fastest-in-memory" assumption.  That
+// matched the helper's INTERNAL layout assumption (view-as-
+// `[D, H, L]` with `nb=[elem, D*elem, HD*elem]`), but it
+// CONTRADICTED what `dense_matmul_time_ggml` actually produces:
+// every Q/K matmul site in the vector estimator hands the helper
+// a tensor with `ne=[L, HD]` (axis 0 = L = time-fastest along
+// natural strides), so memory layout is **channel-major-flat**
+// (`data[t + c*L]`) — the transpose of what the helper expects.
 //
-// Test contract
-// -------------
-// Build a synthetic Q packed in `[H*D, L]` time-major layout
-// (rows = time-frames, channels = `h*D + d` packed).  Verify on
-// the CPU backend that `apply_rope_to_packed_qk(ctx, Q, cos, sin)`
-// produces the same buffer as the scalar `apply_rope` would have
-// written if Q had been laid out as `[t*H + h]*D + d`.
+// On any backend (CPU, OpenCL, Vulkan), the synth path therefore
+// either:
+//   - Crashes on the helper's `GGML_ASSERT(HD == n_heads *
+//     head_dim)` (the new assertion catches the shape mismatch
+//     before the view trick produces garbage), OR
+//   - Pre-assertion, would have produced TRANSPOSED bytes and
+//     silently fed wrong-layout Q / K into
+//     `ggml_flash_attn_ext`.
 //
-// Two parity shapes:
-//   1. Vector-estimator Q: q_len = 20, n_heads = 4, head_dim = 64
-//      → ne[0] = 256, ne[1] = 20.
-//   2. Vector-estimator K: kv_len = 32 (text_len), n_heads = 4,
-//      head_dim = 64 → ne[0] = 256, ne[1] = 32.
+// This test reproduces the real production layout end-to-end on
+// the CPU backend (which has no probe-gating and no per-backend
+// kernel paths to confuse the picture) and verifies the helper:
+//   1. Accepts `ne=[L, HD]` matmul-shaped Q without aborting.
+//   2. Returns post-rotation bytes in the **time-major-flat**
+//      layout (`out[t*HD + c]`) that:
+//        - Matches the scalar `apply_rope(theta, x, L, H, D)`
+//          reference (the SOLE source of truth — every host-side
+//          comparison in the codebase indexes through `t*H*D +
+//          h*D + d` flat).
+//        - Can be uploaded byte-for-byte into
+//          `q_tc_in = ggml_new_tensor_2d(F32, A, L)` whose
+//          natural strides are `nb=[elem, A*elem]` → same flat
+//          layout `data[c + t*A]`.
 //
-// Tolerance: `1e-4` absolute — same band as
-// `test_supertonic_rope_in_graph.cpp` (the inner helper).
+// The L=1 trip-wire is kept (catches a future regression where
+// the helper silently divides by L or swaps the angle formula).
 //
 // Registered with `LABEL "unit"` — no GGUF required.
 
@@ -70,11 +83,11 @@ int g_checks   = 0;
 } while (0)
 
 // Mirror of the in-tree scalar `apply_rope` (private to
-// supertonic_vector_estimator.cpp).  Index layout matches the
-// `data[t*H*D + h*D + d]` arrangement that the dense-matmul
-// output produces when reshaped as `[t * (H*D) + (h*D + d)]` —
-// i.e., the [H*D, L] packed tensor's element (col=h*D+d, row=t)
-// is at the same memory location as scalar's i1 / i2.
+// supertonic_vector_estimator.cpp).  Indexes a single flat buffer
+// as `data[t*H*D + h*D + d]` — the time-major-flat layout every
+// scalar comparison in the vector estimator uses (and the layout
+// `q_tc_in` reads via `ggml_backend_tensor_copy` of
+// `ggml_nbytes(q_tc_in)` bytes).
 void scalar_apply_rope(const float * theta,
                        std::vector<float> & x,
                        int L, int H, int D) {
@@ -96,15 +109,16 @@ void scalar_apply_rope(const float * theta,
     }
 }
 
-// Build a randomized Q in the packed [H*D, L] time-major layout
-// (a single contiguous row-major buffer where element (col, row)
-// sits at `row * H*D + col`).  The same buffer interpreted under
-// the scalar layout `data[t*H*D + h*D + d]` matches when col is
-// decoded as `h*D + d` and row as `t`.  So scalar_apply_rope can
-// be invoked directly on the same buffer for the reference.
-void test_packed_rope_shape(const char * label, int L, int n_heads, int head_dim,
+// Run `apply_rope_to_packed_qk` on a Q with the production matmul
+// shape ne=[L, HD] (channel-major-flat memory `data[t + c*L]`)
+// and verify the rotated output matches the scalar reference's
+// time-major-flat layout (`out[t*HD + c]`) bit-for-bit on the CPU
+// backend.
+void test_production_layout(const char * label, int L, int n_heads, int head_dim,
                             unsigned seed) {
-    std::fprintf(stderr, "[apply_rope_to_packed_qk: %s]  L=%d H=%d D=%d\n",
+    std::fprintf(stderr,
+                 "[apply_rope_to_packed_qk production layout: %s]  "
+                 "L=%d H=%d D=%d  (matmul ne=[L, HD])\n",
                  label, L, n_heads, head_dim);
 
     const int HD = n_heads * head_dim;
@@ -116,33 +130,45 @@ void test_packed_rope_shape(const char * label, int L, int n_heads, int head_dim
     std::vector<float> theta(half);
     for (auto & v : theta) v = std::abs(dist(rng)) * 1000.0f;
 
-    // Packed Q buffer: ne=[HD, L], element (col, row) at memory
-    // index `row * HD + col`.  Random init.
-    std::vector<float> q_packed((size_t) L * HD);
-    for (auto & v : q_packed) v = dist(rng);
+    // Reference: time-major-flat buffer `ref[t*HD + c]`.  Random
+    // init.  This is the source of truth — `scalar_apply_rope`
+    // indexes through `(t*H + h)*D + d` = `t*HD + (h*D + d)`.
+    std::vector<float> ref((size_t) L * HD);
+    for (auto & v : ref) v = dist(rng);
 
-    // Reference: scalar_apply_rope writes via index `t*H*D + h*D + d`
-    // = `t*HD + (h*D + d)`.  For (col=h*D+d, row=t), memory is the
-    // SAME index.  So the scalar in-place rotation applied to a
-    // copy of q_packed gives our reference vector.
-    std::vector<float> ref = q_packed;
+    // Transpose to channel-major-flat for upload to a tensor with
+    // ne=[L, HD] (natural strides nb=[elem, L*elem]).  Element
+    // (t, c) in matmul layout lives at flat index `t + c*L` —
+    // contiguous in t for fixed c.
+    std::vector<float> q_in_buf((size_t) L * HD);
+    for (int t = 0; t < L; ++t) {
+        for (int c = 0; c < HD; ++c) {
+            q_in_buf[(size_t) t + (size_t) c * L] =
+                ref[(size_t) t * HD + c];
+        }
+    }
+
+    // Scalar reference in-place rotation on the time-major-flat
+    // buffer.
     scalar_apply_rope(theta.data(), ref, L, n_heads, head_dim);
 
-    // Host-side cos/sin tables exactly like make_rope_cos_sin_tables
-    // would write: ne=[half, L], element (d, t) at index `t*half + d`.
+    // Cos/sin tables exactly like `make_rope_cos_sin_tables`
+    // writes.
     std::vector<float> cos_host, sin_host;
     make_rope_cos_sin_tables(theta.data(), L, half, cos_host, sin_host);
 
-    // Build the helper's graph on the CPU backend.
-    constexpr int MAX_NODES = 256;
+    // Build the graph on the CPU backend.  Max nodes generous
+    // for the transpose + cont + view chain inside the helper.
+    constexpr int MAX_NODES = 512;
     const size_t buf_size = ggml_tensor_overhead() * MAX_NODES + ggml_graph_overhead();
     std::vector<uint8_t> buf(buf_size);
     ggml_init_params p = { buf_size, buf.data(), /*no_alloc=*/true };
     ggml_context * ctx = ggml_init(p);
     ggml_cgraph * gf = ggml_new_graph(ctx);
 
-    // q input: ne=[HD, L] (axis 0 = packed channels, axis 1 = time).
-    ggml_tensor * q_in = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, HD, L);
+    // q input with the production matmul shape.  ne=[L, HD]
+    // explicitly DIFFERENT from the pre-fix test's ne=[HD, L].
+    ggml_tensor * q_in = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, L, HD);
     ggml_set_name(q_in, "q_in"); ggml_set_input(q_in);
     ggml_tensor * cos_in = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, half, L);
     ggml_set_name(cos_in, "cos_in"); ggml_set_input(cos_in);
@@ -154,7 +180,13 @@ void test_packed_rope_shape(const char * label, int L, int n_heads, int head_dim
     ggml_set_name(y, "y"); ggml_set_output(y);
     ggml_build_forward_expand(gf, y);
 
-    // Run on CPU backend.
+    // Output-shape contract.  The helper MUST produce ne=[HD, L]
+    // (axis 0 = HD = channels-fastest, axis 1 = L = time-slowest)
+    // for `ggml_backend_tensor_copy(y, q_tc_in)` to hit the
+    // matching shape in `vector_text_attention_cache::q_tc_in`.
+    CHECK((int) y->ne[0] == HD);
+    CHECK((int) y->ne[1] == L);
+
     ggml_backend_t cpu = ggml_backend_cpu_init();
     if (!cpu) {
         std::fprintf(stderr, "  SKIP: ggml_backend_cpu_init failed\n");
@@ -165,7 +197,7 @@ void test_packed_rope_shape(const char * label, int L, int n_heads, int head_dim
     ggml_gallocr_reserve(allocr, gf);
     ggml_gallocr_alloc_graph(allocr, gf);
 
-    ggml_backend_tensor_set(q_in,   q_packed.data(), 0, q_packed.size() * sizeof(float));
+    ggml_backend_tensor_set(q_in,   q_in_buf.data(), 0, q_in_buf.size() * sizeof(float));
     ggml_backend_tensor_set(cos_in, cos_host.data(), 0, cos_host.size() * sizeof(float));
     ggml_backend_tensor_set(sin_in, sin_host.data(), 0, sin_host.size() * sizeof(float));
     ggml_backend_graph_compute(cpu, gf);
@@ -176,10 +208,9 @@ void test_packed_rope_shape(const char * label, int L, int n_heads, int head_dim
     ggml_free(ctx);
     ggml_backend_free(cpu);
 
-    // Shape contract: output must have the same total nelements
-    // as q_packed (so a downstream ggml_set_output + tensor_to_time_
-    // channel can consume it identically).
-    CHECK(got.size() == q_packed.size());
+    // Memory-layout contract: helper's output bytes should equal
+    // scalar reference's time-major-flat bytes element-wise.
+    CHECK(got.size() == ref.size());
 
     int bad = 0;
     float max_abs = 0.0f;
@@ -202,35 +233,43 @@ void test_packed_rope_shape(const char * label, int L, int n_heads, int head_dim
     CHECK(bad == 0);
 }
 
-// Trip-wire: when L=1 the helper still needs to work (degenerate
-// time axis matches the way the front-block builds a single-step
-// graph after the convnext + time-add path).
-void test_packed_rope_l1() {
-    std::fprintf(stderr, "[apply_rope_to_packed_qk: L=1 degenerate]\n");
+// L=1 trip-wire (preserved from the original test).  At L=1 the
+// angle is 0/1 * theta = 0, so cos=1, sin=0 and rotation is the
+// identity.  Catches a regression where the helper accidentally
+// divides by L or swaps the angle formula.  Re-cast under the
+// production ne=[L, HD] contract.
+void test_production_layout_l1() {
+    std::fprintf(stderr,
+                 "[apply_rope_to_packed_qk production layout: L=1 degenerate]\n");
     const int L = 1, n_heads = 2, head_dim = 8;
     const int HD = n_heads * head_dim;
     const int half = head_dim / 2;
 
     std::vector<float> theta(half, 100.0f);
-    std::vector<float> q_packed((size_t) L * HD, 1.0f);
 
-    // At L=1 the angle is 0/1 * theta = 0, so cos=1, sin=0, and the
-    // rotation is identity.  Catches a regression where the helper
-    // accidentally divides by L or swaps the angle formula.
-    std::vector<float> ref = q_packed;
+    // Time-major-flat reference; channel-major-flat upload.
+    std::vector<float> ref((size_t) L * HD, 1.0f);
+    std::vector<float> q_in_buf((size_t) L * HD);
+    for (int t = 0; t < L; ++t) {
+        for (int c = 0; c < HD; ++c) {
+            q_in_buf[(size_t) t + (size_t) c * L] =
+                ref[(size_t) t * HD + c];
+        }
+    }
+    // Identity rotation at L=1.
     scalar_apply_rope(theta.data(), ref, L, n_heads, head_dim);
 
     std::vector<float> cos_host, sin_host;
     make_rope_cos_sin_tables(theta.data(), L, half, cos_host, sin_host);
 
-    constexpr int MAX_NODES = 64;
+    constexpr int MAX_NODES = 128;
     const size_t buf_size = ggml_tensor_overhead() * MAX_NODES + ggml_graph_overhead();
     std::vector<uint8_t> buf(buf_size);
     ggml_init_params p = { buf_size, buf.data(), true };
     ggml_context * ctx = ggml_init(p);
     ggml_cgraph * gf = ggml_new_graph(ctx);
 
-    ggml_tensor * q_in = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, HD, L);
+    ggml_tensor * q_in = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, L, HD);
     ggml_set_input(q_in);
     ggml_tensor * cos_in = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, half, L);
     ggml_set_input(cos_in);
@@ -247,7 +286,7 @@ void test_packed_rope_l1() {
     ggml_gallocr_t allocr = ggml_gallocr_new(ggml_backend_get_default_buffer_type(cpu));
     ggml_gallocr_reserve(allocr, gf);
     ggml_gallocr_alloc_graph(allocr, gf);
-    ggml_backend_tensor_set(q_in,   q_packed.data(), 0, q_packed.size() * sizeof(float));
+    ggml_backend_tensor_set(q_in,   q_in_buf.data(), 0, q_in_buf.size() * sizeof(float));
     ggml_backend_tensor_set(cos_in, cos_host.data(), 0, cos_host.size() * sizeof(float));
     ggml_backend_tensor_set(sin_in, sin_host.data(), 0, sin_host.size() * sizeof(float));
     ggml_backend_graph_compute(cpu, gf);
@@ -256,6 +295,9 @@ void test_packed_rope_l1() {
     ggml_gallocr_free(allocr);
     ggml_free(ctx);
     ggml_backend_free(cpu);
+
+    CHECK((int) y->ne[0] == HD);
+    CHECK((int) y->ne[1] == L);
 
     int bad = 0;
     float max_abs = 0.0f;
@@ -268,13 +310,40 @@ void test_packed_rope_l1() {
     CHECK(bad == 0);
 }
 
+// Output-shape regression check.  Even if the helper ever gets
+// re-plumbed to a different internal pipeline, the public contract
+// must remain `ne[0] = n_heads * head_dim`, `ne[1] = L` so the
+// downstream `ggml_backend_tensor_copy` blit into
+// `vector_text_attention_cache::q_tc_in` stays bit-exact.
+void test_output_shape_contract() {
+    std::fprintf(stderr,
+                 "[apply_rope_to_packed_qk output-shape contract]\n");
+    const int L = 20, n_heads = 4, head_dim = 64;
+    const int HD = n_heads * head_dim;
+    const int half = head_dim / 2;
+    const size_t buf_size = ggml_tensor_overhead() * 256 + ggml_graph_overhead();
+    std::vector<uint8_t> buf(buf_size);
+    ggml_init_params p = { buf_size, buf.data(), true };
+    ggml_context * ctx = ggml_init(p);
+    ggml_tensor * q_in = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, L, HD);
+    ggml_tensor * cos_in = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, half, L);
+    ggml_tensor * sin_in = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, half, L);
+    ggml_tensor * y = apply_rope_to_packed_qk(ctx, q_in, cos_in, sin_in,
+                                              n_heads, head_dim);
+    CHECK((int) y->ne[0] == HD);
+    CHECK((int) y->ne[1] == L);
+    CHECK(ggml_nelements(y) == (int64_t) L * HD);
+    ggml_free(ctx);
+}
+
 } // namespace
 
 int main() {
     // Vector-estimator hot shapes (q_len, kv_len typical sizes).
-    test_packed_rope_shape("vector-estimator q", 20, 4, 64, 0xA51C);
-    test_packed_rope_shape("vector-estimator k", 32, 4, 64, 0xC0FF);
-    test_packed_rope_l1();
+    test_production_layout("vector-estimator q", 20, 4, 64, 0xA51C);
+    test_production_layout("vector-estimator k", 32, 4, 64, 0xC0FF);
+    test_production_layout_l1();
+    test_output_shape_contract();
 
     std::fprintf(stderr,
                  "test_supertonic_rope_packed_qk: %d / %d checks passed\n",


### PR DESCRIPTION
## Summary

Single-commit critical fix for the CPU regression on `supertonic_optimizations` reported in [QVAC-18966]. The packed-QK RoPE helper introduced by audit follow-up #5 (PR #16, commit `5869231c`) aborts on the first denoise step of every Supertonic synth run with `--n-gpu-layers 0` against any GGUF carrying `vector_rope_theta`:

```
supertonic_internal.h:742:
  GGML_ASSERT(HD == (int64_t) n_heads * head_dim) failed
  in apply_rope_to_packed_qk → supertonic_vector_trace_proj_ggml
  → supertonic_vector_step_ggml → supertonic_vector_loop_ggml
```

The regression is **not** on `master` — it only affects `supertonic_optimizations` and branches derived from it. This PR is the one-commit fix; the rest of the branch is untouched.

## Root cause

`apply_rope_to_packed_qk` (PR #16 audit follow-up #5) was written under the assumption that `dense_matmul_time_ggml` returns a `ne=[HD, L]` tensor with channel-fastest-in-memory layout. In fact the matmul — both the CPU `cblas_sgemm` fast path (`ggml_custom_4d(F32, x->ne[0] /* = L */, w->ne[0] /* = OC */, …)` → `[L, OC]`) and the universal `conv1d_f32(K=1)` fallback (`ggml_reshape_3d(result, im2col->ne[1] /* = L */, kernel->ne[2] /* = OC */, …)` → also `[L, OC]`) — produces `ne=[L, HD]` with channel-major-flat memory (`data[t + c*L]`), the bit-exact transpose of the helper's input contract.

The CPU unit test that landed alongside the helper (`test_supertonic_rope_packed_qk.cpp`) hand-built Q under the wrong `[HD, L]` shape, matching the helper's internal layout assumption verbatim, so the failure mode was invisible to CI. The first end-to-end synth attempt against a GGUF with `vector_rope_theta` hits the defensive assertion.

## Fix (strict TDD)

1. **`test_supertonic_rope_packed_qk.cpp`** rewritten under the production matmul shape `ne=[L, HD]` (channel-major-flat memory). Reference built in scalar `apply_rope`'s native time-major-flat layout; test verifies the helper's output bytes match bit-for-bit AND pins `y->ne[0] = HD, y->ne[1] = L` so the downstream `q_tc_in` blit cannot regress on layout. Added an explicit output-shape contract test (`test_output_shape_contract`). Committed RED first, observed to abort at the same assertion the production crash hits.

2. **`apply_rope_to_packed_qk`** (`supertonic_internal.h`): added a head-of-pipeline `ggml_cont(ggml_transpose(q))` to flip from `ne=[L, HD]` channel-major-flat to `ne=[HD, L]` time-major-flat (the layout `q_tc_in` expects). Rest of the pipeline (view-as-`[D, H, L]` + cont + `apply_rope_in_graph` + reshape) is unchanged. Output `ne=[HD, L]` time-major-flat bytes match scalar `apply_rope`'s native layout AND `q_tc_in`'s blit target bit-for-bit. Universal-op only (`ggml_transpose`, `ggml_cont`, `ggml_view_3d`, `ggml_reshape_2d`); no new backend dispatch.

3. **V matmul layout fix** at two GPU-bridge call sites (V has no RoPE to mask the layout flip):
   - `build_group_graph_cache` — per-group attention V
   - `supertonic_vector_trace_proj_ggml` — front-block attention V

   Open-coded the same `ggml_cont(ggml_transpose(...))` at the matmul output so the GPU-bridge `ggml_backend_tensor_copy(v_src, v_tc_in)` lands bit-exact bytes in `v_tc_in` (`ne=[HD, kv_len]` time-major-flat). Style sq/sk/sv intentionally **not** touched — this branch (unlike the Vulkan branch) has no GPU bridge for style attention (`sq_gpu` / `sk_gpu` / `sv_gpu` don't exist here), so the existing host-vector path via `tensor_to_time_channel` is already correct and adding a transpose would break it.

4. **Legacy host-bridge fallbacks** switched from `tensor_to_time_channel(<post-rope-or-v>)` to `tensor_raw_f32(...)` at:
   - `run_group_graph_cache`: `out.v`, `out.q_rope`, `out.k_rope`
   - Front-block dispatch in `supertonic_vector_trace_proj_ggml`: `v_out`, `q_rotated`, `k_rotated`

   The new graph-side layout puts the bytes already in the time-major-flat shape scalar `apply_rope` / `flash_attention_qkv` host references read, so the raw download is the correct call. `tensor_to_time_channel` would now apply the transpose-of-the-transpose and feed wrong-orientation Q/K/V into the attention silently. Pre-RoPE Q/K downloads (still `ne=[L, HD]` channel-major-flat) stay on `tensor_to_time_channel` — correct as before.

## Test contract

```
test-supertonic-rope-packed-qk
  test_production_layout("vector-estimator q", L=20, H=4, D=64)  → bit-exact
  test_production_layout("vector-estimator k", L=32, H=4, D=64)  → bit-exact
  test_production_layout_l1()                                    → bit-exact
  test_output_shape_contract()                                   → ne[0]=HD, ne[1]=L
14 / 14 checks pass, max_abs_err = 0.000e+00
```

Whole `ctest -L unit`: **12 / 12 pass, 0 regressions, 0 flakes**.

## Verification on the exact QVAC-18966 reproduction command

```bash
./build/supertonic-cli --model models/supertonic2.gguf \
  --text "Hello world." --out /tmp/out.wav \
  --voice F1 --n-gpu-layers 0 --seed 42
```

| Check | Pre-fix | Post-fix |
|---|---|---|
| Short synth ("Hello world.") | abort on first step | `wrote /tmp/out.wav (1.35s @ 44100 Hz, 59479 samples)` |
| Long synth (~6 s of audio) | abort | works |
| Multi-voice (F1, M1) | abort | both work |
| Determinism (same seed × 2) | n/a | bit-identical (`md5sum` match) |
| Audio sanity (rms / abs_max / nonzero%) | n/a | rms=1406, abs_max=15984, 99.9% non-zero — speech-like dynamics |

## Risks & mitigations

- **Cross-backend safety.** The four layout changes in this commit are byte-for-byte identical to what the Vulkan branch (`b54b7d43` round 11) already shipped and validated end-to-end on Vulkan RTX 5090 + AMD RADV iGPU + Mesa lavapipe, with the deliberate exception of `build_res_style_qkv_cache` (no GPU bridge for style on this branch). The helper itself uses universal-only ops, so no backend dispatch table change.
- **Trace-mode contract preserved.** Trace harnesses consume `q / k / q_rope / k_rope / v` host vectors. Pre-RoPE Q/K are still downloaded via `tensor_to_time_channel` (matmul output is unchanged). Post-RoPE Q/K and post-transpose V are downloaded via `tensor_raw_f32` — the new graph-side bytes are already in the time-major-flat shape every existing scalar-parity test reads (`out[t*H*D + h*D + d]`).
- **Non-RoPE GGUFs (`vector_rope_theta` absent).** `cache.apply_rope = false` short-circuits the helper call entirely; the V transpose still runs but produces the same time-major-flat bytes the host bridge expects, just plumbed through `tensor_raw_f32` instead of `tensor_to_time_channel`. No code path regresses.
- **Per-group + front-block parity.** The four affected call sites (front block + g1 + g2 + g3) all see the same helper output shape contract and the same V transpose, so the per-group ConvNeXt + style residual + tail chains downstream are byte-stable.

## What this PR does NOT touch

- `master` is unaffected (regression isn't there).
- No new optimisation, no new probe, no new CLI flag, no new EngineOption.
- `build_res_style_qkv_cache` / `run_res_style_qkv_cache` left alone — see note above.
- The two unrelated pre-existing missing-include build fixes (`#include <atomic>` in `chatterbox_tts.cpp` from upstream commit `1819b681`; `#include <cstring>` in `supertonic_vector_estimator.cpp` from the Metal-port commit `5403d10c`) are **not** part of this commit. They live in the working tree only so the local build can compile; they should land via separate cherry-picks from master if needed.

## Commits in this PR

1 commit, 3 files changed, +366 / −129.

| # | Commit | Theme |
|---|---|---|
| 1 | `dfdbc924` | QVAC-18966 fix: head-of-pipeline transpose in `apply_rope_to_packed_qk` + V matmul transposes at the two GPU-bridge sites + host-bridge fallback download switches. |

## Tested platforms

- Linux x86-64, GCC build, `--n-gpu-layers 0` (CPU). 12 / 12 unit tests pass; CLI end-to-end on `models/supertonic2.gguf` succeeds.

Other backends (OpenCL / Vulkan / Metal / CUDA) were not exercised on this branch's working tree (no local GPU available for this fix's verification); however the fix is byte-for-byte the same as what the Vulkan branch shipped after end-to-end validation on those backends, and the new ops in the helper are all universal — no backend can refuse them.
