### PR TITLE
QVAC-18966: tts-cpp — add missing <atomic> include in chatterbox_tts.cpp

### DIFF
--- a/tts-cpp/src/chatterbox_tts.cpp
+++ b/tts-cpp/src/chatterbox_tts.cpp
@@ -43,6 +43,7 @@
 #endif
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cmath>
 #include <cstdint>


### PR DESCRIPTION
## Summary

One-line fix. `tts-cpp/src/chatterbox_tts.cpp` declares
```cpp
static std::atomic<int> g_s3gen_cache_refcount{0};
```
at line ~189 (and later uses `.fetch_add()`, `.fetch_sub()`, `.store()`), but the translation unit never `#include <atomic>` directly. libstdc++ has historically exposed `std::atomic` transitively via `<mutex>` so the build appears clean on most setups, but the transitive path is being trimmed in the ggml-speech v0.10.2 sync currently in flight on [`tetherto/qvac-ext-ggml#13`](https://github.com/tetherto/qvac-ext-ggml/pull/13). On the merged speech HEAD, `chatterbox_tts.cpp` fails to compile with:

```
chatterbox_tts.cpp:189:30: error: aggregate 'std::atomic<int> g_s3gen_cache_refcount'
                                  has incomplete type and cannot be defined
```

The fault reproduces on the **pre-merge** `speech` HEAD too if you trim a few headers — the include chain has just been hiding a latent bug.

Add `#include <atomic>` explicitly. No behavioural change; safe under any header transitivity.

## Tasks

- QVAC-18966 (Asana) — TTS-GGML CPU regression / build-fix series. This is the build half (`chatterbox_tts.cpp` no longer relies on transitive `<atomic>`).

## Validation

Clean rebuild of `tts-cpp` (master + this PR) against a shared-libs install of [`tetherto/qvac-ext-ggml#13`](https://github.com/tetherto/qvac-ext-ggml/pull/13) HEAD `45dbdecd` (the day-2 v0.10.2 merge target):

```bash
# install ggml-speech as shared libs
cmake -S qvac-ext-ggml -B build-install -G Ninja \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_INSTALL_PREFIX=/tmp/ggml-speech-install/usr/local \
  -DBUILD_SHARED_LIBS=ON -DGGML_LIB_OUTPUT_PREFIX=qvac-speech- \
  -DGGML_VULKAN=ON -DGGML_NATIVE=OFF
cmake --build build-install -j && cmake --install build-install

# rebuild tts-cpp against it
cmake -S qvac-ext-lib-whisper.cpp/tts-cpp -B tts-validate -G Ninja \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_PREFIX_PATH="…;/tmp/ggml-speech-install/usr/local" \
  -DTTS_CPP_BUILD_LIBRARY=ON
cmake --build tts-validate -j
# -> libtts-cpp.a built clean, chatterbox_tts.cpp.o compiled in 3 variants
```

## Notes

- Purely additive (a single `#include <atomic>` line). Independent of every other PR in the QVAC-18991 / 18992 / 18993 series.
- Cherry-picked off the combined `QVAC-18993-bundled-ggml-android-dynamic-backend` branch where it was originally written; that combined branch will be closed in favour of this PR (single-concern) plus the QVAC-18993 ggml-bundled PR (the other two commits).

Made with [Cursor](https://cursor.com)