### PR TITLE
QVAC-18993: bundled-ggml — Android dynamic backend + per-arch CPU dlopen fallback

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -185,9 +185,8 @@ endif()
 
 # ggml
 
-if (GGML_BACKEND_DL AND NOT BUILD_SHARED_LIBS)
-    message(FATAL_ERROR "GGML_BACKEND_DL requires BUILD_SHARED_LIBS")
-endif()
+# QVAC-18993: GGML_BACKEND_DL works with a static core when PIC is
+# enabled below (mirrors the speech-stack patch in qvac-ext-ggml).
 
 add_library(ggml-base
             ../include/ggml.h
@@ -265,7 +264,7 @@ function(ggml_add_backend_library backend)
     target_link_libraries(${backend} PRIVATE ggml-base)
     target_include_directories(${backend} PRIVATE ..)
 
-    if (${BUILD_SHARED_LIBS})
+    if (BUILD_SHARED_LIBS OR GGML_BACKEND_DL)
         target_compile_definitions(${backend} PRIVATE GGML_BACKEND_BUILD)
         target_compile_definitions(${backend} PUBLIC  GGML_BACKEND_SHARED)
     endif()
@@ -484,7 +483,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "visionOS")
     target_compile_definitions(ggml-base PUBLIC _DARWIN_C_SOURCE)
 endif()
 
-if (BUILD_SHARED_LIBS)
+if (BUILD_SHARED_LIBS OR GGML_BACKEND_DL)
     foreach (target ggml-base ggml)
         set_target_properties(${target} PROPERTIES POSITION_INDEPENDENT_CODE ON)
         target_compile_definitions(${target} PRIVATE GGML_BUILD)

--- a/ggml/src/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-backend-reg.cpp
@@ -534,6 +534,97 @@ static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent,
                 }
             }
         }
+#ifdef __ANDROID__
+        // QVAC-18993: Android app packaging keeps native libraries
+        // compressed inside the APK with no on-disk directory to scan
+        // (the default since AGP 3.6's `useLegacyPackaging=false`).
+        // The directory-iterator loop above therefore finds nothing on
+        // Android and the per-search_path `fs::exists` fallback also
+        // returns false. Try the bare filename instead and let Android's
+        // dynamic linker resolve it via the in-APK lookup.
+        //
+        // For backends that ship as a single library (Vulkan / OpenCL /
+        // ...) the bare `lib<prefix>ggml-<name>.so` filename is enough.
+        // For the CPU backend with `GGML_CPU_ALL_VARIANTS=ON` there is
+        // no plain `lib<prefix>ggml-cpu.so`, only the per-arch
+        // `lib<prefix>ggml-cpu-android_armv*_*.so` files, so we also
+        // try each known per-arch variant and let `ggml_backend_score`
+        // pick the highest-scoring one the device's HWCAP supports.
+        //
+        // Mirrors qvac-ext-ggml@speech commit 9562ed04 ("ggml-backend:
+        // android per-arch CPU variant dlopen fallback") so APK
+        // consumers of the bundled-ggml whisper-cpp port get the same
+        // Android-correct CPU init as ggml-speech consumers (parakeet,
+        // chatterbox, ...).
+        //
+        // TODO: keep this list in sync with the
+        // `ggml_add_cpu_backend_variant(android_armv*_*)` calls in
+        // ggml/src/CMakeLists.txt. New tiers added there must be
+        // appended here as well, or devices on the new tier will
+        // silently fall back to a lower one (perf hit).
+        std::vector<fs::path> candidate_names = { name_path };
+        if (strcmp(name, "cpu") == 0) {
+            candidate_names.emplace_back("cpu-android_armv8.0_1");
+            candidate_names.emplace_back("cpu-android_armv8.2_1");
+            candidate_names.emplace_back("cpu-android_armv8.2_2");
+            candidate_names.emplace_back("cpu-android_armv8.6_1");
+            candidate_names.emplace_back("cpu-android_armv9.0_1");
+            candidate_names.emplace_back("cpu-android_armv9.2_1");
+            candidate_names.emplace_back("cpu-android_armv9.2_2");
+        }
+
+        if (candidate_names.size() == 1) {
+            // Fast path: Vulkan / OpenCL / Metal / ... single-shot dlopen.
+            fs::path filename = backend_filename_prefix().native() +
+                                candidate_names[0].native() +
+                                backend_filename_extension().native();
+            if (auto reg = get_reg().load_backend(filename, silent)) {
+                return reg;
+            }
+            return nullptr;
+        }
+
+        // Multi-candidate (Android CPU today): iterate worst -> best with
+        // a synthetic per-index offset on top of the runtime score so
+        // that on a device that accepts every variant (e.g. armv9.2
+        // phone) the highest tier wins on tie, while a device that
+        // legitimately supports only the baseline still picks armv8.0_1.
+        for (size_t idx = 0; idx < candidate_names.size(); ++idx) {
+            fs::path filename = backend_filename_prefix().native() +
+                                candidate_names[idx].native() +
+                                backend_filename_extension().native();
+            dl_handle_ptr handle { dl_load_library(filename) };
+            if (!handle) {
+                if (!silent) {
+                    GGML_LOG_DEBUG("%s: dlopen(%s) failed: %s\n", __func__,
+                                   path_str(filename).c_str(), dl_error());
+                }
+                continue;
+            }
+            auto score_fn = (ggml_backend_score_t)
+                dl_get_sym(handle.get(), "ggml_backend_score");
+            int s = 1; // base score for backends without ggml_backend_score
+            if (score_fn) {
+                s = score_fn();
+                if (s == 0) {
+                    continue;
+                }
+            }
+            s += static_cast<int>(idx);
+#ifndef NDEBUG
+            GGML_LOG_DEBUG("%s: %s score: %d\n", __func__,
+                           path_str(filename).c_str(), s);
+#endif
+            if (s > best_score) {
+                best_score = s;
+                best_path = filename;
+            }
+        }
+
+        if (best_score > 0) {
+            return get_reg().load_backend(best_path, silent);
+        }
+#endif // __ANDROID__
         return nullptr;
     }
 


### PR DESCRIPTION
## Summary

> **Day-4 update (2026-05-20).** Group 1 ([PR #25](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/25)) + Group 2 ([PR #27](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/27)) merged into `master` (HEAD `e5677f7f`). This PR remains mergeable on top of new master (clean fast-forward, no rebase needed). The two CI failures (`ios-xcode-build (Release)`, `bindings-java`) are **pre-existing on `tetherto/master`** — verified against the latest completed master CI run `26094102232` on `08df2e70`: identical failures reproduce without this PR's commits.

Two bundled-ggml changes that together make the `whisper-cpp` vcpkg port's `arm64-android` recipe actually work end-to-end. **No tts-cpp or upstream-sync changes** — those are split out into their own PRs ([PR #27](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/27) and [PR #25](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/25) respectively, both now merged).

### Commits

- **`400bf929`** `ggml : allow GGML_BACKEND_DL with a static core (QVAC-18993)`

  Replaces `BUILD_SHARED_LIBS` with `BUILD_SHARED_LIBS OR GGML_BACKEND_DL` on three guards in `ggml/src/CMakeLists.txt` (FATAL_ERROR removed; PIC + `GGML_BUILD` enabled on `ggml-base`/`ggml`; `GGML_BACKEND_SHARED`/`GGML_BACKEND_BUILD` defs on each backend). The combo `-DGGML_BACKEND_DL=ON -DBUILD_SHARED_LIBS=OFF` is the exact shape the `arm64-android` triplet uses (vcpkg forces static linkage) and produces a static dispatcher + MODULE backend `.so` files — works end-to-end, only the configure-time check rejected it.

  Mirrors the equivalent change already on `qvac-ext-ggml@speech` for the parallel speech-stack consumers (parakeet-cpp / tts-cpp).

- **`c1d7a6c9`** `ggml-backend : android per-arch CPU variant dlopen fallback (QVAC-18993)`

  Android APK consumers built with the AGP ≥ 3.6 default (`useLegacyPackaging=false`) keep `.so` libraries compressed inside the APK — `fs::exists()` returns false for every backend candidate and `ggml_backend_load_best()` would return nullptr. The single-library backends (Vulkan / OpenCL / …) already resolve via Android's in-APK linker when the bare `lib<prefix>ggml-<name>.so` is tried; the CPU backend ships only as per-arch variants when `GGML_CPU_ALL_VARIANTS=ON`, so the bare-name fallback finds nothing.

  Enumerate the seven known per-arch CPU variant filenames as additional candidates for the "cpu" backend on `__ANDROID__`, then run each through the standard `ggml_backend_score` selector so the device's HWCAP picks the right tier (armv8.0 baseline → armv9.2_2). Fast-path the size-1 case so non-Android targets keep their previous codepath cost.

  Mirrors [`qvac-ext-ggml@speech` 9562ed04](https://github.com/tetherto/qvac-ext-ggml/commit/9562ed04) ([@GustavoA1604](https://github.com/GustavoA1604), PR #11).

## Tasks

- **QVAC-18993** — Enable Android dynamic backend build for the `whisper-cpp` vcpkg port.

## Validation

**NDK r29 Android cross-compile** with the exact recipe the vcpkg port uses on `arm64-android`:

```bash
cmake -S . -B build-android \
  -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake \
  -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-28 \
  -DCMAKE_BUILD_TYPE=Release \
  -DGGML_BACKEND_DL=ON -DBUILD_SHARED_LIBS=OFF \
  -DGGML_CPU_ALL_VARIANTS=ON -DGGML_CPU_REPACK=ON \
  -DGGML_NATIVE=OFF \
  -DGGML_VULKAN=OFF -DGGML_METAL=OFF -DGGML_OPENCL=OFF \
  -DWHISPER_BUILD_TESTS=OFF -DWHISPER_BUILD_EXAMPLES=OFF -DWHISPER_BUILD_SERVER=OFF
cmake --build build-android -j
```

- All 7 per-arch `libggml-cpu-android_armv*_*.so` files produced clean:
  ```
  libggml-cpu-android_armv8.0_1.so
  libggml-cpu-android_armv8.2_1.so
  libggml-cpu-android_armv8.2_2.so
  libggml-cpu-android_armv8.6_1.so
  libggml-cpu-android_armv9.0_1.so
  libggml-cpu-android_armv9.2_1.so
  libggml-cpu-android_armv9.2_2.so
  ```
- `strings ggml-backend-reg.cpp.o | grep cpu-android_armv` confirms all 7 candidate names compile into the dispatcher object.

**OnePlus 7T Pro on-device validation** (previous run, see `aiDocs/06-on-device-validation.md`): dynamic backend loading works, CPU inference matches CPU-only baseline (per-arch `armv8.2_1` selected by HWCAP), Vulkan and OpenCL backends register and report expected hardware-policy decisions.

**Indirect consumer CI validation** (Day-4, via [qvac PR #2124](https://github.com/tetherto/qvac/pull/2124)): the source content of this PR is exercised through the `whisper-cpp 1.8.4.3#3` vcpkg port pinned to `Zbig9000/qvac-ext-lib-whisper.cpp@14620c88` (which is the tree-equivalent of merged PR #25 + merged PR #27 + this PR). Android NDK r29 cross-compile in CI produced all 7 per-arch `libggml-cpu-android_armv*_*.so` files + `libggml-vulkan.so` clean. Full audit in `aiDocs/12-group3-ci-audit.md`.

## CI status

`build.yml` matrix on this PR's HEAD `c1d7a6c9`:

| Aggregate | Count |
| --- | --- |
| ✅ SUCCESS | 57 |
| ⏭ SKIPPED | 2 |
| ❌ FAILURE (pre-existing on master) | 2 |

The two failures — `CI / ios-xcode-build (Release)` and `CI / bindings-java` — both reproduce on `tetherto/master` HEAD `08df2e70` (latest completed master run, predates this PR). Neither is introduced by the commits in this PR.

## Cross-repo PR set

- ✅ **Merged**: [PR #25](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/25) — QVAC-18991: pull latest whisper.cpp from upstream.
- ✅ **Merged**: [PR #27](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/27) — QVAC-18966: `tts-cpp <atomic>` include fix.
- 🟢 **This PR (#28)** — QVAC-18993: bundled-ggml Android dynamic backend.
- 🟢 Open: [qvac-ext-ggml PR #13](https://github.com/tetherto/qvac-ext-ggml/pull/13) — QVAC-18992: merge ggml-org v0.10.2 into speech.
- 🟢 Open: [vcpkg PR #152](https://github.com/tetherto/qvac-registry-vcpkg/pull/152) — registry: speech-stack + Android dynamic backends.
- 🟢 Open: [qvac PR #2124](https://github.com/tetherto/qvac/pull/2124) — production `transcription-whispercpp 0.7.3` bump.

## Notes for reviewer

- Once this PR merges, the `whisper-cpp` vcpkg port ([PR #152](https://github.com/tetherto/qvac-registry-vcpkg/pull/152)) can flip its REF from `Zbig9000/qvac-ext-lib-whisper.cpp@14620c88` to `tetherto/qvac-ext-lib-whisper.cpp@<merge SHA>` (or to a tagged commit if one is published). The intermediate `14620c88` branch is the tree-equivalent of merged PR #25 + merged PR #27 + this PR.