### PR TITLE
QVAC-19213 fix: make the vulkan backend work on adreno (qualcomm) gpus

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -2991,6 +2991,7 @@ static vk_fa_tuning_params get_fa_tuning_params_scalar(const vk_device& device, 
         result.workgroup_size = result.subgroup_size * 4;
     }
 
+
     const uint32_t D = hsk | hsv;
 
     const bool reduce_block_rows = D & 8 || n_kv < 1024 || device->vendor_id == VK_VENDOR_ID_INTEL;
@@ -7395,6 +7396,16 @@ static vk_pipeline ggml_vk_guess_matmul_pipeline(ggml_backend_vk_context * ctx, 
     if ((mm_m && (m <= 64 || n <= 64)) || !mm_l) {
         return aligned ? mmp->a_m : mmp->m;
     }
+    // QVAC-19213 Adreno workaround: the matmul `_l` (large) tile variant
+    // (BLOCK_SIZE=128, two Adreno wave64 warps per workgroup) crashes the
+    // Adreno Vulkan driver in vk::Queue::submit on the whisper-medium.en
+    // encoder matmuls (confirmed iQOO 11 / SD8Gen2 / Adreno 740 / driver
+    // E031.41.03.64, 2026-05-22). The M (medium) tile uses BLOCK_SIZE=64
+    // (one Adreno warp per workgroup) and is known-good on this driver.
+    // Costs ~4x more workgroup dispatches on Adreno; no correctness change.
+    if (ctx->device->vendor_id == VK_VENDOR_ID_QUALCOMM && mm_m) {
+        return aligned ? mmp->a_m : mmp->m;
+    }
     return aligned ? mmp->a_l : mmp->l;
 }
 
@@ -7480,6 +7491,16 @@ static vk_pipeline ggml_vk_guess_matmul_id_pipeline(ggml_backend_vk_context * ct
         return aligned ? mmp->a_s : mmp->s;
     }
     if ((mm_m && (m <= 64 || n <= 64)) || !mm_l) {
+        return aligned ? mmp->a_m : mmp->m;
+    }
+    // QVAC-19213 Adreno workaround: the matmul `_l` (large) tile variant
+    // (BLOCK_SIZE=128, two Adreno wave64 warps per workgroup) crashes the
+    // Adreno Vulkan driver in vk::Queue::submit on the whisper-medium.en
+    // encoder matmuls (confirmed iQOO 11 / SD8Gen2 / Adreno 740 / driver
+    // E031.41.03.64, 2026-05-22). The M (medium) tile uses BLOCK_SIZE=64
+    // (one Adreno warp per workgroup) and is known-good on this driver.
+    // Costs ~4x more workgroup dispatches on Adreno; no correctness change.
+    if (ctx->device->vendor_id == VK_VENDOR_ID_QUALCOMM && mm_m) {
         return aligned ? mmp->a_m : mmp->m;
     }
     return aligned ? mmp->a_l : mmp->l;
@@ -9272,6 +9293,7 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
         aligned = false;
     }
 
+
     float scale         = 1.0f;
     float max_bias      = 0.0f;
     float logit_softcap = 0.0f;
@@ -9795,11 +9817,21 @@ static vk_pipeline ggml_vk_op_get_pipeline(ggml_backend_vk_context * ctx, const 
             return ctx->device->pipeline_topk_moe[idx][use_push];
         }
 
+        // QVAC-19213 Adreno workaround: the wg512 softmax variant
+        // (BLOCK_SIZE=512, 8 subgroups × 64-thread Adreno subgroup) hangs
+        // the Adreno Vulkan driver in vk::Queue::waitIdle on the decoder
+        // cross-attention dispatch (confirmed iQOO 11 / SD8Gen2 /
+        // Adreno 740 / Android 16, 2026-05-22). The smaller-wg variant
+        // works. Slight perf cost on large rows on Adreno only; all other
+        // vendors keep the existing behaviour. Inlined to avoid declaring
+        // a var in the switch-case scope (jump-bypasses-init).
         if (src0->type == GGML_TYPE_F32 && (src1 == nullptr || src1->type == GGML_TYPE_F32) && dst->type == GGML_TYPE_F32) {
-            return src0->ne[0] > 1024 ? ctx->device->pipeline_soft_max_f32_wg512 : ctx->device->pipeline_soft_max_f32;
+            const bool use_wg512 = src0->ne[0] > 1024 && ctx->device->vendor_id != VK_VENDOR_ID_QUALCOMM;
+            return use_wg512 ? ctx->device->pipeline_soft_max_f32_wg512 : ctx->device->pipeline_soft_max_f32;
         }
         if (src0->type == GGML_TYPE_F32 && src1->type == GGML_TYPE_F16 && dst->type == GGML_TYPE_F32) {
-            return src0->ne[0] > 1024 ? ctx->device->pipeline_soft_max_f32_f16_wg512 : ctx->device->pipeline_soft_max_f32_f16;
+            const bool use_wg512 = src0->ne[0] > 1024 && ctx->device->vendor_id != VK_VENDOR_ID_QUALCOMM;
+            return use_wg512 ? ctx->device->pipeline_soft_max_f32_f16_wg512 : ctx->device->pipeline_soft_max_f32_f16;
         }
         return nullptr;
     case GGML_OP_SOFT_MAX_BACK:
@@ -14030,7 +14062,17 @@ static size_t ggml_backend_vk_buffer_type_get_alignment(ggml_backend_buffer_type
 
 static size_t ggml_backend_vk_buffer_type_get_max_size(ggml_backend_buffer_type_t buft) {
     ggml_backend_vk_buffer_type_context * ctx = (ggml_backend_vk_buffer_type_context *) buft->context;
-    return ctx->device->suballocation_block_size;
+    // QVAC-19213: report the smaller of the suballocation block size and the
+    // per-descriptor storage buffer range. Sub-allocation can carve a huge
+    // buffer into chunks, but a single dispatch can only bind a descriptor up
+    // to maxStorageBufferRange. Tensors larger than that can't be used by any
+    // ggml op except IM2COL (BDA path). Callers that respect get_max_size --
+    // e.g. allocating a kv-cache -- can use this to fall back to CPU buffer.
+    // Spec-mandated minimum is 128 MiB; some Adreno drivers expose exactly
+    // that, breaking whisper-medium's kv-cross which needs >128 MiB tensors.
+    size_t alloc_block = ctx->device->suballocation_block_size;
+    size_t desc_range  = ctx->device->properties.limits.maxStorageBufferRange;
+    return std::min(alloc_block, desc_range);
 }
 
 static size_t ggml_backend_vk_buffer_type_get_alloc_size(ggml_backend_buffer_type_t buft, const ggml_tensor * tensor) {
@@ -15993,6 +16035,22 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
             }
         case GGML_OP_FLASH_ATTN_EXT:
             {
+                // QVAC-19213 Adreno workaround: the Adreno Vulkan driver
+                // (Adreno 740 / driver E031.41.03.64) fails SPIR-V compile
+                // for every flash_attn_f32_f16 variant we have tested
+                // (aligned / non-aligned, with / without subgroup hints).
+                // vk::Device::createComputePipeline returns ErrorUnknown.
+                // Falling back here causes the scheduler to route FA ops to
+                // CPU. This is necessary for whisper-medium.en + larger:
+                // without FA the explicit attention scores tensor is
+                // 1500 x 1500 x n_audio_head x f32 = 144 MB (medium) /
+                // 180 MB+ (large), which exceeds Adreno's 128 MB
+                // maxStorageBufferRange. Routing FA to CPU keeps Q, K, V on
+                // GPU and copies them out per FA op (acceptable until the FA
+                // shader compile is fixed for Adreno).
+                if (device->vendor_id == VK_VENDOR_ID_QUALCOMM) {
+                    return false;
+                }
                 bool coopmat2 = device->coopmat2;
                 uint32_t HSK = op->src[1]->ne[0];
                 uint32_t HSV = op->src[2]->ne[0];

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -14050,10 +14050,14 @@ static size_t ggml_backend_vk_buffer_type_get_alignment(ggml_backend_buffer_type
 
 static size_t ggml_backend_vk_buffer_type_get_max_size(ggml_backend_buffer_type_t buft) {
     ggml_backend_vk_buffer_type_context * ctx = (ggml_backend_vk_buffer_type_context *) buft->context;
-    // Report min(suballocation block size, maxStorageBufferRange): a single
-    // dispatch can't bind a descriptor larger than maxStorageBufferRange.
     size_t alloc_block = ctx->device->suballocation_block_size;
-    size_t desc_range  = ctx->device->properties.limits.maxStorageBufferRange;
+    // Adreno (Qualcomm) can't bind a single descriptor larger than
+    // maxStorageBufferRange (128 MiB), so cap there; other vendors keep
+    // the full suballocation block size.
+    if (ctx->device->vendor_id != VK_VENDOR_ID_QUALCOMM) {
+        return alloc_block;
+    }
+    size_t desc_range = ctx->device->properties.limits.maxStorageBufferRange;
     return std::min(alloc_block, desc_range);
 }
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4304,9 +4304,13 @@ static void ggml_vk_load_shaders(vk_device& device) {
     }
     uint32_t rm_iq = 2 * rm_kq;
 
-    const bool use_subgroups = device->subgroup_arithmetic && device->architecture != vk_device_architecture::AMD_GCN;
+    // Adreno (Qualcomm) crashes compiling the mul_mat_vec subgroup
+    // variant; force the equivalent shmem-reduction path instead.
+    bool use_subgroups = device->subgroup_arithmetic && device->architecture != vk_device_architecture::AMD_GCN;
+    if (device->vendor_id == VK_VENDOR_ID_QUALCOMM) { use_subgroups = false; }
     // Ensure a subgroup size >= 16 is available
-    const bool use_subgroups16 = use_subgroups && subgroup_min_size_16;
+    bool use_subgroups16 = use_subgroups && subgroup_min_size_16;
+    if (device->vendor_id == VK_VENDOR_ID_QUALCOMM) { use_subgroups16 = false; }
 
     const uint32_t subgroup_size = (device->vendor_id == VK_VENDOR_ID_INTEL && device->subgroup_size_control && device->subgroup_min_size <= 16 && device->subgroup_max_size >= 16) ? 16 : device->subgroup_size;
     const uint32_t subgroup_size16 = std::max(subgroup_size, 16u);
@@ -7396,13 +7400,8 @@ static vk_pipeline ggml_vk_guess_matmul_pipeline(ggml_backend_vk_context * ctx, 
     if ((mm_m && (m <= 64 || n <= 64)) || !mm_l) {
         return aligned ? mmp->a_m : mmp->m;
     }
-    // QVAC-19213 Adreno workaround: the matmul `_l` (large) tile variant
-    // (BLOCK_SIZE=128, two Adreno wave64 warps per workgroup) crashes the
-    // Adreno Vulkan driver in vk::Queue::submit on the whisper-medium.en
-    // encoder matmuls (confirmed iQOO 11 / SD8Gen2 / Adreno 740 / driver
-    // E031.41.03.64, 2026-05-22). The M (medium) tile uses BLOCK_SIZE=64
-    // (one Adreno warp per workgroup) and is known-good on this driver.
-    // Costs ~4x more workgroup dispatches on Adreno; no correctness change.
+    // Adreno (Qualcomm) crashes on the matmul `_l` (large) tile;
+    // fall back to the `_m` (medium) tile, which is known-good.
     if (ctx->device->vendor_id == VK_VENDOR_ID_QUALCOMM && mm_m) {
         return aligned ? mmp->a_m : mmp->m;
     }
@@ -7493,13 +7492,8 @@ static vk_pipeline ggml_vk_guess_matmul_id_pipeline(ggml_backend_vk_context * ct
     if ((mm_m && (m <= 64 || n <= 64)) || !mm_l) {
         return aligned ? mmp->a_m : mmp->m;
     }
-    // QVAC-19213 Adreno workaround: the matmul `_l` (large) tile variant
-    // (BLOCK_SIZE=128, two Adreno wave64 warps per workgroup) crashes the
-    // Adreno Vulkan driver in vk::Queue::submit on the whisper-medium.en
-    // encoder matmuls (confirmed iQOO 11 / SD8Gen2 / Adreno 740 / driver
-    // E031.41.03.64, 2026-05-22). The M (medium) tile uses BLOCK_SIZE=64
-    // (one Adreno warp per workgroup) and is known-good on this driver.
-    // Costs ~4x more workgroup dispatches on Adreno; no correctness change.
+    // Adreno (Qualcomm) crashes on the matmul `_l` (large) tile;
+    // fall back to the `_m` (medium) tile, which is known-good.
     if (ctx->device->vendor_id == VK_VENDOR_ID_QUALCOMM && mm_m) {
         return aligned ? mmp->a_m : mmp->m;
     }
@@ -9817,14 +9811,8 @@ static vk_pipeline ggml_vk_op_get_pipeline(ggml_backend_vk_context * ctx, const 
             return ctx->device->pipeline_topk_moe[idx][use_push];
         }
 
-        // QVAC-19213 Adreno workaround: the wg512 softmax variant
-        // (BLOCK_SIZE=512, 8 subgroups × 64-thread Adreno subgroup) hangs
-        // the Adreno Vulkan driver in vk::Queue::waitIdle on the decoder
-        // cross-attention dispatch (confirmed iQOO 11 / SD8Gen2 /
-        // Adreno 740 / Android 16, 2026-05-22). The smaller-wg variant
-        // works. Slight perf cost on large rows on Adreno only; all other
-        // vendors keep the existing behaviour. Inlined to avoid declaring
-        // a var in the switch-case scope (jump-bypasses-init).
+        // Adreno (Qualcomm) hangs on the wg512 softmax variant; fall back to
+        // the smaller-wg variant (inlined to avoid a switch-scope var).
         if (src0->type == GGML_TYPE_F32 && (src1 == nullptr || src1->type == GGML_TYPE_F32) && dst->type == GGML_TYPE_F32) {
             const bool use_wg512 = src0->ne[0] > 1024 && ctx->device->vendor_id != VK_VENDOR_ID_QUALCOMM;
             return use_wg512 ? ctx->device->pipeline_soft_max_f32_wg512 : ctx->device->pipeline_soft_max_f32;
@@ -14062,14 +14050,8 @@ static size_t ggml_backend_vk_buffer_type_get_alignment(ggml_backend_buffer_type
 
 static size_t ggml_backend_vk_buffer_type_get_max_size(ggml_backend_buffer_type_t buft) {
     ggml_backend_vk_buffer_type_context * ctx = (ggml_backend_vk_buffer_type_context *) buft->context;
-    // QVAC-19213: report the smaller of the suballocation block size and the
-    // per-descriptor storage buffer range. Sub-allocation can carve a huge
-    // buffer into chunks, but a single dispatch can only bind a descriptor up
-    // to maxStorageBufferRange. Tensors larger than that can't be used by any
-    // ggml op except IM2COL (BDA path). Callers that respect get_max_size --
-    // e.g. allocating a kv-cache -- can use this to fall back to CPU buffer.
-    // Spec-mandated minimum is 128 MiB; some Adreno drivers expose exactly
-    // that, breaking whisper-medium's kv-cross which needs >128 MiB tensors.
+    // Report min(suballocation block size, maxStorageBufferRange): a single
+    // dispatch can't bind a descriptor larger than maxStorageBufferRange.
     size_t alloc_block = ctx->device->suballocation_block_size;
     size_t desc_range  = ctx->device->properties.limits.maxStorageBufferRange;
     return std::min(alloc_block, desc_range);
@@ -16035,19 +16017,8 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
             }
         case GGML_OP_FLASH_ATTN_EXT:
             {
-                // QVAC-19213 Adreno workaround: the Adreno Vulkan driver
-                // (Adreno 740 / driver E031.41.03.64) fails SPIR-V compile
-                // for every flash_attn_f32_f16 variant we have tested
-                // (aligned / non-aligned, with / without subgroup hints).
-                // vk::Device::createComputePipeline returns ErrorUnknown.
-                // Falling back here causes the scheduler to route FA ops to
-                // CPU. This is necessary for whisper-medium.en + larger:
-                // without FA the explicit attention scores tensor is
-                // 1500 x 1500 x n_audio_head x f32 = 144 MB (medium) /
-                // 180 MB+ (large), which exceeds Adreno's 128 MB
-                // maxStorageBufferRange. Routing FA to CPU keeps Q, K, V on
-                // GPU and copies them out per FA op (acceptable until the FA
-                // shader compile is fixed for Adreno).
+                // Adreno (Qualcomm) fails to compile every flash_attn variant;
+                // return false to route flash-attention ops to CPU.
                 if (device->vendor_id == VK_VENDOR_ID_QUALCOMM) {
                     return false;
                 }

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -1019,7 +1019,25 @@ static bool whisper_kv_cache_init(
     cache.k = ggml_new_tensor_1d(ctx, wtype, n_elements);
     cache.v = ggml_new_tensor_1d(ctx, wtype, n_elements);
 
-    cache.buffer = ggml_backend_alloc_ctx_tensors(ctx, backend);
+    // QVAC-19213 Adreno fallback: if a single K or V tensor exceeds the
+    // backend's max single-tensor size (e.g. Vulkan's per-descriptor
+    // storageBufferRange, 128 MiB on Adreno 740), the GPU backend cannot
+    // bind the descriptor at dispatch and graph scheduling will abort with
+    // "pre-allocated tensor in a buffer that cannot run the operation". Fall
+    // back to the host (CPU) buffer type for THIS cache only; ops that
+    // touch K/V will get scheduled on CPU with K/V copy when needed, but
+    // the rest of the graph keeps using the GPU backend. Affects whisper-
+    // medium and larger on Adreno; bigger GPUs and CPU-only are unaffected.
+    const size_t per_tensor_bytes      = ggml_nbytes(cache.k);
+    const size_t backend_max           = ggml_backend_get_max_size(backend);
+    ggml_backend_buffer_type_t buft    = ggml_backend_get_default_buffer_type(backend);
+    if (per_tensor_bytes > backend_max) {
+        WHISPER_LOG_INFO("%s: kv cache tensor %.2f MB exceeds backend max %.2f MB; using CPU buffer\n",
+            __func__, per_tensor_bytes / 1e6, backend_max / 1e6);
+        buft = ggml_backend_cpu_buffer_type();
+    }
+
+    cache.buffer = ggml_backend_alloc_ctx_tensors_from_buft(ctx, buft);
     if (!cache.buffer) {
         WHISPER_LOG_ERROR("%s: failed to allocate memory for the kv cache\n", __func__);
         return false;

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -1019,15 +1019,9 @@ static bool whisper_kv_cache_init(
     cache.k = ggml_new_tensor_1d(ctx, wtype, n_elements);
     cache.v = ggml_new_tensor_1d(ctx, wtype, n_elements);
 
-    // QVAC-19213 Adreno fallback: if a single K or V tensor exceeds the
-    // backend's max single-tensor size (e.g. Vulkan's per-descriptor
-    // storageBufferRange, 128 MiB on Adreno 740), the GPU backend cannot
-    // bind the descriptor at dispatch and graph scheduling will abort with
-    // "pre-allocated tensor in a buffer that cannot run the operation". Fall
-    // back to the host (CPU) buffer type for THIS cache only; ops that
-    // touch K/V will get scheduled on CPU with K/V copy when needed, but
-    // the rest of the graph keeps using the GPU backend. Affects whisper-
-    // medium and larger on Adreno; bigger GPUs and CPU-only are unaffected.
+    // If a single K/V tensor exceeds the backend's max single-tensor size,
+    // the GPU can't bind the descriptor; allocate this cache from the CPU
+    // buffer type so K/V ops run on CPU while the rest stays on GPU.
     const size_t per_tensor_bytes      = ggml_nbytes(cache.k);
     const size_t backend_max           = ggml_backend_get_max_size(backend);
     ggml_backend_buffer_type_t buft    = ggml_backend_get_default_buffer_type(backend);


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Whisper's **Vulkan** GPU backend does not work on Qualcomm **Adreno** GPUs — the most common Android GPU family — so those devices can't use GPU acceleration at all.
- Concretely on Adreno 740 (Snapdragon 8 Gen 2) and Adreno 830 (Galaxy S25), Vulkan hits driver `DeviceLost` crashes, a GLSL-compiler segfault, and a `>128 MB` buffer assertion abort — across the tiny/base/small/medium models.

## 📝 How does it solve it?

Narrow, vendor-gated (`VK_VENDOR_ID_QUALCOMM`) workarounds for the specific shader paths Adreno's driver mishandles, plus one whisper-side buffer-placement fallback. All gates are no-ops on non-Qualcomm devices, so other backends are unchanged.

- **softmax** — skip the 512-wide-workgroup variant (triggers `DeviceLost`).
- **matmul** — use the medium (single-warp) tile instead of the large tile (triggers `DeviceLost` on encoder shapes).
- **flash-attention** — route to CPU; the scalar-FA SPIR-V fails to compile on Adreno.
- **mul_mat_vec** — force the shared-memory reduction instead of the subgroup path, which crashes Adreno's GLSL compiler.
- **kv-cache** (`whisper.cpp`) — when a single K/V tensor exceeds the device `maxStorageBufferRange` (128 MB on Adreno), allocate it in a CPU buffer instead of the GPU buffer.

## 🧪 How was it tested?

- **iQOO 11 (SD8 Gen 2, Adreno 740), Android 16, driver E031.41.03.64:** `tiny/base/small/medium.en` all transcribe `jfk.wav` correctly on Vulkan (matching the CPU baseline text). Without these changes each model crashes or aborts.
- **AWS Device Farm:** Samsung Galaxy S25 Ultra (Adreno 830, Qualcomm) and Google Pixel 9 Pro (Mali) — the mobile GPU E2E suite passed on both. The S25 perf report reports `execution_provider: gpu` with a distinct GPU profile (genuine GPU execution, not a silent CPU fallback), no teardown crash, and the Mali (non-Qualcomm) path is unaffected.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215063497621974