### PR TITLE
QVAC-19252 tts-cpp: don't block-quantize S3Gen spk_embed_affine (fixed sub-f16 NaN audio)

### DIFF
--- a/tts-cpp/scripts/requantize-gguf.py
+++ b/tts-cpp/scripts/requantize-gguf.py
@@ -70,6 +70,10 @@ import gguf
 _DENY_SUBSTRINGS = (
     # Raw-F32 access in the C++ loader
     "flow/input_embedding",     # S3Gen speech embedding table (read as F32 for CPU-side lookup)
+    "flow/spk_embed_affine",    # speaker-embedding affine (w + b): read as raw F32 by
+                                # cached_cpu_weights_f32 in the s3gen synth path, so a
+                                # block-quantized tensor would be byte-reinterpreted as
+                                # float -> NaN speaker embedding -> all-NaN mel -> noise.
     "/builtin/",                # voice conditioning tensors, loaded directly
     # Embedding tables (accessed via ggml_get_rows — safer as F16/F32)
     "text_emb",                 # T3 text token embedding

--- a/tts-cpp/src/chatterbox_tts.cpp
+++ b/tts-cpp/src/chatterbox_tts.cpp
@@ -583,6 +583,17 @@ static std::unordered_map<int, std::vector<float>>                       g_stft_
 // live as F32, so a templated variant for F16/Q8_0 isn't needed here.
 static const float * cached_cpu_weights_f32(const ggml_tensor * t) {
     if (!t) return nullptr;
+    // Hard invariant: this path memcpys ggml_nbytes() raw bytes into an F32
+    // buffer and uses them as floats, so a block-quantized tensor would be
+    // byte-reinterpreted as float -> NaN.  Fail loudly (naming the tensor)
+    // so a mis-quantized raw-read weight is caught at load time, not heard.
+    if (t->type != GGML_TYPE_F32) {
+        throw std::runtime_error(
+            std::string("cached_cpu_weights_f32: '") + ggml_get_name(t) +
+            "' must be F32 but is " + ggml_type_name(t->type) +
+            "; this weight is read raw on the CPU side and must not be "
+            "block-quantized (add it to the converter deny-list).");
+    }
     {
         std::lock_guard<std::mutex> lk(g_synth_caches_mu);
         auto it = g_weight_cpu_mirror.find(t);


### PR DESCRIPTION
flow/spk_embed_affine/w was eligible for block quantization (2-D, ne[0]=192 divisible by 32, not deny-listed) but is read back as raw F32 by cached_cpu_weights_f32() in the S3Gen synth path. At q8_0/q5_0/q4_0 the quantized bytes were reinterpreted as IEEE floats -> NaN speaker embedding -> all-NaN mel -> noise. Backend-independent; hit every sub-f16 level.

Fix: add "flow/spk_embed_affine" to _DENY_SUBSTRINGS in requantize-gguf.py (the single source of truth shared by both converters and the offline requantizer), so the affine weights stay F32. Surgical: exactly one fewer tensor block-quantized; everything else is unchanged (encoder_proj stays quantized -- it is consumed via ggml_mul_mat and dequantized correctly).

Harden: cached_cpu_weights_f32() now throws if handed a non-F32 tensor, naming it, so any future raw-F32-read weight that slips into the quant set fails loudly at load time instead of emitting silent NaN audio.

Verified on Turbo S3Gen (host CPU, full text->speech): pre-fix q8 = noise (cos 0.003 vs f16), fixed q8 = clean (cos 0.990 vs f16); the guard trips on the pre-fix GGUF naming flow/spk_embed_affine/w.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215009851268640