### PR TITLE
QVAC-19253 tts-cpp: Supertonic + Chatterbox on Adreno-Vulkan

### DIFF
--- a/tts-cpp/src/chatterbox_cli.cpp
+++ b/tts-cpp/src/chatterbox_cli.cpp
@@ -1071,7 +1071,12 @@ int tts_cpp_cli_main(int argc, char ** argv) {
                         throw std::runtime_error("failed to load --reference-audio");
                     normalise_lufs(wav, sr, -27.0);
                     if (sr != 16000) wav = resample_sinc(wav, sr, 16000);
-                    if (!voice_encoder_embed(wav, vew, vc_backend, se_bake))
+                    // Voice-encoder on CPU (nullptr -> own CPU backend): same
+                    // one-time LSTM with strided-view activations + a >128MB gate
+                    // matmul that single-backend GPU compute can't do (see the
+                    // synthesis paths). S3TokenizerV2 / CAMPPlus below stay on
+                    // vc_backend -- they run fine on GPU.
+                    if (!voice_encoder_embed(wav, vew, /*backend=*/nullptr, se_bake))
                         throw std::runtime_error("VoiceEncoder forward failed");
                 }
                 fprintf(stderr, "BENCH: VC_STAGE_speaker_emb_ms=%lld\n", (long long)((ggml_time_us() - _t0)/1000));
@@ -1223,9 +1228,13 @@ int tts_cpp_cli_main(int argc, char ** argv) {
                     throw std::runtime_error("failed to load --reference-audio for VoiceEncoder");
                 normalise_lufs(wav, sr, -27.0);
                 if (sr != 16000) wav = resample_sinc(wav, sr, 16000);
-                // Reuse the T3 backend — already loaded & sitting on the GPU
-                // at this point in the flow.
-                if (!voice_encoder_embed(wav, vew, model.backend, se_data))
+                // Voice-encoder runs on CPU (nullptr -> its own CPU backend): a
+                // one-time conditioning step whose LSTM feeds strided views to
+                // activations and builds a >128MB gate matmul -- neither is valid
+                // under single-backend GPU compute (Vulkan's unary shaders are
+                // contiguous-only; Adreno caps a descriptor at 128MB). The
+                // skip-reference path already computes it on CPU.
+                if (!voice_encoder_embed(wav, vew, /*backend=*/nullptr, se_data))
                     throw std::runtime_error("VoiceEncoder forward failed");
                 have_se = true;
             } else {

--- a/tts-cpp/src/chatterbox_engine.cpp
+++ b/tts-cpp/src/chatterbox_engine.cpp
@@ -334,7 +334,11 @@ struct Engine::Impl {
                 }
                 normalise_lufs(wav, sr, -27.0);
                 if (sr != 16000) wav = resample_sinc(wav, sr, 16000);
-                if (!voice_encoder_embed(wav, vew, model.backend, se_data)) {
+                // CPU regardless of model backend: a one-time LSTM conditioning
+                // step with strided-view activations + a >128MB gate matmul, which
+                // are invalid under single-backend GPU compute (see
+                // chatterbox_cli.cpp). nullptr -> own CPU backend.
+                if (!voice_encoder_embed(wav, vew, /*backend=*/nullptr, se_data)) {
                     throw std::runtime_error("Engine: VoiceEncoder forward failed");
                 }
                 have_se = true;

--- a/tts-cpp/src/supertonic_duration.cpp
+++ b/tts-cpp/src/supertonic_duration.cpp
@@ -119,7 +119,7 @@ ggml_tensor * edge_clamp_pad_1d(ggml_context * ctx, ggml_tensor * x, int pad_lef
     if (pad_left == 0 && pad_right == 0) return x;
     static const bool disable_fused_edge_pad =
         std::getenv("SUPERTONIC_DISABLE_FUSED_EDGE_PAD") != nullptr;
-    if (!disable_fused_edge_pad &&
+    if (!disable_fused_edge_pad && supertonic_use_fused_supertonic_ops() &&
         x->type == GGML_TYPE_F32 &&
         x->ne[2] == 1 && x->ne[3] == 1 &&
         ggml_is_contiguous(x)) {
@@ -149,7 +149,7 @@ ggml_tensor * depthwise_same_ggml(ggml_context * ctx,
     const int K = (int) w->ne[0];
     static const bool disable_fused =
         std::getenv("SUPERTONIC_DISABLE_FUSED_DEPTHWISE") != nullptr;
-    if (!disable_fused && (K == 3 || K == 5) &&
+    if (!disable_fused && supertonic_use_fused_supertonic_ops() && (K == 3 || K == 5) &&
         x->type == GGML_TYPE_F32 && w->type == GGML_TYPE_F32 &&
         b->type == GGML_TYPE_F32 &&
         x->ne[2] == 1 && x->ne[3] == 1 && w->ne[1] == 1 && w->ne[3] == 1 &&
@@ -170,7 +170,7 @@ ggml_tensor * depthwise_same_ggml(ggml_context * ctx,
 ggml_tensor * layer_norm_ggml(ggml_context * ctx, ggml_tensor * x, ggml_tensor * g, ggml_tensor * b) {
     static const bool disable_fused_layer_norm =
         std::getenv("SUPERTONIC_DISABLE_FUSED_LAYER_NORM") != nullptr;
-    if (!disable_fused_layer_norm &&
+    if (!disable_fused_layer_norm && supertonic_use_fused_supertonic_ops() &&
         x->type == GGML_TYPE_F32 && g->type == GGML_TYPE_F32 && b->type == GGML_TYPE_F32 &&
         x->ne[2] == 1 && x->ne[3] == 1 &&
         g->ne[0] == x->ne[1] && b->ne[0] == x->ne[1] &&

--- a/tts-cpp/src/supertonic_gguf.cpp
+++ b/tts-cpp/src/supertonic_gguf.cpp
@@ -285,6 +285,39 @@ bool backend_supports_native_leaky_relu(ggml_backend_t backend) {
     return ok;
 }
 
+// Backend capability probe for the Supertonic fused custom ops
+// (GGML_OP_SUPERTONIC_*).  Builds a throwaway depthwise_1d node with the
+// minimal valid shape (a=[L,C] F32, w=[K=3,1,C,1] F32, b=[C] F32) inside a
+// no-alloc scratch context and asks the backend whether it would accept it.
+// ggml-cpu and ggml-metal implement the supertonic ops; ggml-vulkan and
+// ggml-opencl do not, so they return false here and the graph-build helpers
+// take the pure-GGML decomposition instead of emitting an op the backend
+// would silently skip.  The 5 fused ops ship as one overlay set (port-version
+// 13), so probing depthwise_1d is representative of all of them.  Runs once
+// per load via the capability cache; zero hot-path cost.
+bool backend_supports_fused_supertonic_ops(ggml_backend_t backend) {
+    if (!backend) return false;
+    ggml_init_params probe_params = {
+        /*.mem_size   =*/ ggml_tensor_overhead() * 8,
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context * probe_ctx = ggml_init(probe_params);
+    if (!probe_ctx) return false;
+    bool ok = false;
+    try {
+        ggml_tensor * a  = ggml_new_tensor_2d(probe_ctx, GGML_TYPE_F32, 8, 4);       // [L=8, C=4]
+        ggml_tensor * w  = ggml_new_tensor_4d(probe_ctx, GGML_TYPE_F32, 3, 1, 4, 1); // [K=3,1,C=4,1]
+        ggml_tensor * b  = ggml_new_tensor_1d(probe_ctx, GGML_TYPE_F32, 4);          // [C=4]
+        ggml_tensor * op = ggml_supertonic_depthwise_1d(probe_ctx, a, w, b, /*dilation=*/1);
+        ok = (op != nullptr) && ggml_backend_supports_op(backend, op);
+    } catch (...) {
+        ok = false;
+    }
+    ggml_free(probe_ctx);
+    return ok;
+}
+
 // QVAC-18605 — runtime check: backend is `ggml-vulkan`.
 //
 // Forwarder to the shared `tts_cpp::detail::backend_is_vulkan`
@@ -613,6 +646,10 @@ struct backend_capabilities {
     // to skip ggml-vulkan's internal staging-buffer hop on the
     // per-step uploads.
     bool pinned_host_buffer;
+    // True iff the backend implements the GGML_OP_SUPERTONIC_* fused ops
+    // (ggml-cpu / ggml-metal yes; ggml-vulkan / ggml-opencl no).  Gates the
+    // fused-op fast paths vs the pure-GGML decomposition in the graph builders.
+    bool fused_supertonic_ops;
 };
 
 inline std::mutex & capability_cache_mu() {
@@ -688,6 +725,7 @@ const backend_capabilities & cached_backend_capabilities(ggml_backend_t backend)
     caps.q8_0_kv_flash_attn  = backend_supports_q8_0_kv_flash_attn_uncached(backend);
     caps.bf16_kv_flash_attn  = backend_supports_bf16_kv_flash_attn_uncached(backend);
     caps.pinned_host_buffer  = backend_supports_pinned_host_buffer_uncached(backend);
+    caps.fused_supertonic_ops = backend_supports_fused_supertonic_ops(backend);
     return c.emplace(backend, caps).first->second;
 }
 
@@ -1338,6 +1376,9 @@ namespace {
 thread_local bool g_supertonic_use_cpu_custom_ops    = true;
 thread_local bool g_supertonic_use_f16_attn          = false;
 thread_local bool g_supertonic_use_native_leaky_relu = true;
+// Defaults to false (pure-GGML) so a helper called outside any dispatch scope
+// never emits a backend-unsupported fused supertonic op.
+thread_local bool g_supertonic_use_fused_supertonic_ops = false;
 // QVAC-18605 round 4 — current K/V flash-attn dispatch dtype.
 // Defaults to f32 so a graph builder called outside any
 // `supertonic_op_dispatch_scope` doesn't accidentally take the
@@ -1357,6 +1398,10 @@ bool supertonic_use_native_leaky_relu() {
     return g_supertonic_use_native_leaky_relu;
 }
 
+bool supertonic_use_fused_supertonic_ops() {
+    return g_supertonic_use_fused_supertonic_ops;
+}
+
 kv_attn_dtype supertonic_kv_attn_type() {
     return g_supertonic_kv_attn_type;
 }
@@ -1365,18 +1410,21 @@ supertonic_op_dispatch_scope::supertonic_op_dispatch_scope(const supertonic_mode
     : prev_use_cpu_custom_ops(g_supertonic_use_cpu_custom_ops),
       prev_use_f16_attn(g_supertonic_use_f16_attn),
       prev_use_native_leaky_relu(g_supertonic_use_native_leaky_relu),
+      prev_use_fused_supertonic_ops(g_supertonic_use_fused_supertonic_ops),
       prev_kv_attn_type(g_supertonic_kv_attn_type) {
-    g_supertonic_use_cpu_custom_ops    = model.backend_is_cpu;
-    g_supertonic_use_f16_attn          = model.use_f16_attn;
-    g_supertonic_use_native_leaky_relu = model.use_native_leaky_relu;
-    g_supertonic_kv_attn_type          = model.kv_attn_type;
+    g_supertonic_use_cpu_custom_ops       = model.backend_is_cpu;
+    g_supertonic_use_f16_attn             = model.use_f16_attn;
+    g_supertonic_use_native_leaky_relu    = model.use_native_leaky_relu;
+    g_supertonic_use_fused_supertonic_ops = model.backend_supports_fused_supertonic_ops;
+    g_supertonic_kv_attn_type             = model.kv_attn_type;
 }
 
 supertonic_op_dispatch_scope::~supertonic_op_dispatch_scope() {
-    g_supertonic_use_cpu_custom_ops    = prev_use_cpu_custom_ops;
-    g_supertonic_use_f16_attn          = prev_use_f16_attn;
-    g_supertonic_use_native_leaky_relu = prev_use_native_leaky_relu;
-    g_supertonic_kv_attn_type          = prev_kv_attn_type;
+    g_supertonic_use_cpu_custom_ops       = prev_use_cpu_custom_ops;
+    g_supertonic_use_f16_attn             = prev_use_f16_attn;
+    g_supertonic_use_native_leaky_relu    = prev_use_native_leaky_relu;
+    g_supertonic_use_fused_supertonic_ops = prev_use_fused_supertonic_ops;
+    g_supertonic_kv_attn_type             = prev_kv_attn_type;
 }
 
 // QVAC-18605 round 4 — pure-logic resolver for the multi-dtype
@@ -1784,11 +1832,14 @@ bool load_supertonic_gguf(const std::string & path,
         // per backend (memoised by `cached_backend_capabilities`)
         // — zero hot-path cost.
         model.use_native_leaky_relu = cached_backend_capabilities(model.backend).native_leaky_relu;
+        model.backend_supports_fused_supertonic_ops =
+            cached_backend_capabilities(model.backend).fused_supertonic_ops;
         if (verbose) {
-            fprintf(stderr, "supertonic: backend_is_cpu=%s backend_is_vk=%s use_native_leaky_relu=%s\n",
+            fprintf(stderr, "supertonic: backend_is_cpu=%s backend_is_vk=%s use_native_leaky_relu=%s fused_supertonic_ops=%s\n",
                     model.backend_is_cpu ? "true" : "false",
                     model.backend_is_vk ? "true" : "false",
-                    model.use_native_leaky_relu ? "true" : "false");
+                    model.use_native_leaky_relu ? "true" : "false",
+                    model.backend_supports_fused_supertonic_ops ? "true" : "false");
         }
 
         // Phase 2A — auto/force policy for F16 weight materialization.

--- a/tts-cpp/src/supertonic_internal.h
+++ b/tts-cpp/src/supertonic_internal.h
@@ -363,6 +363,21 @@ struct supertonic_model {
     // overhead on the GPU command-buffer side.  Default `true`
     // matches the historical CPU-only path.
     bool use_native_leaky_relu = true;
+    // True when the resolved backend implements the Supertonic fused custom
+    // ops (GGML_OP_SUPERTONIC_DEPTHWISE_1D / LAYER_NORM_CHANNEL / EDGE_PAD_1D /
+    // BIAS_GELU / PW2_RESIDUAL).  Those are implemented in ggml-cpu and
+    // ggml-metal only — NOT ggml-vulkan / ggml-opencl.  Resolved at load time
+    // via `ggml_backend_supports_op` against a synthetic depthwise_1d node
+    // (the 5 ops ship as one overlay set, so one probe is representative).
+    // The graph-build helpers (depthwise_same_ggml / layer_norm_ggml /
+    // edge_clamp_pad_1d / bias_gelu_ggml / pw2_residual_ggml in both the text
+    // encoder and vector estimator, plus vector_convnext_ggml_ct) gate the
+    // fused fast path on this; when false they emit the pure-GGML decomposition
+    // (im2col+mul_mat / ggml_norm / concat+repeat / add+gelu / matmul+scale+add)
+    // which every backend executes.  Without this gate the fused ops are
+    // silently skipped on Vulkan/OpenCL single-backend graphs → garbage output.
+    // Default false = safe (pure-GGML) until the load-time probe runs.
+    bool backend_supports_fused_supertonic_ops = false;
     // When true, the per-step vector-estimator attention graphs materialise
     // K/V into contiguous F16 before calling ggml_flash_attn_ext so OpenCL
     // (and other backends carrying the mixed-precision kernel) dispatch
@@ -1037,6 +1052,15 @@ inline ggml_tensor * leaky_relu_portable_ggml(ggml_context * ctx, ggml_tensor * 
 // still sees the default `true` after a GPU engine's forward returns.
 bool supertonic_use_cpu_custom_ops();
 bool supertonic_use_f16_attn();
+// Thread-local mirror of `supertonic_model::backend_supports_fused_supertonic_ops`,
+// set by `supertonic_op_dispatch_scope` for the duration of each public
+// `*_forward_ggml` / `*_trace_ggml` entry (same RAII pattern as
+// `supertonic_use_cpu_custom_ops` / `supertonic_use_native_leaky_relu`).
+// Graph-build helpers consult it to choose the fused custom op vs the
+// pure-GGML decomposition.  Defaults to `false` (pure-GGML) when no scope
+// is active, so a helper called outside a scope never emits a backend-
+// unsupported fused op.
+bool supertonic_use_fused_supertonic_ops();
 
 // QVAC-18605 round 4 — thread-local accessor for the currently-
 // active K/V dispatch dtype, mirroring `supertonic_use_f16_attn`'s
@@ -1338,6 +1362,7 @@ struct supertonic_op_dispatch_scope {
     bool prev_use_cpu_custom_ops;
     bool prev_use_f16_attn;
     bool prev_use_native_leaky_relu;
+    bool prev_use_fused_supertonic_ops;
     // QVAC-18605 round 4 — saved K/V dispatch dtype for RAII
     // teardown.  Restored on scope destruction so a follow-on
     // engine on the same thread sees the default value, not the

--- a/tts-cpp/src/supertonic_text_encoder.cpp
+++ b/tts-cpp/src/supertonic_text_encoder.cpp
@@ -172,7 +172,7 @@ ggml_tensor * edge_clamp_pad_1d(ggml_context * ctx, ggml_tensor * x, int pad_lef
     if (pad_left == 0 && pad_right == 0) return x;
     static const bool disable_fused_edge_pad =
         std::getenv("SUPERTONIC_DISABLE_FUSED_EDGE_PAD") != nullptr;
-    if (!disable_fused_edge_pad &&
+    if (!disable_fused_edge_pad && supertonic_use_fused_supertonic_ops() &&
         x->type == GGML_TYPE_F32 &&
         x->ne[2] == 1 && x->ne[3] == 1 &&
         ggml_is_contiguous(x)) {
@@ -198,7 +198,7 @@ ggml_tensor * depthwise_same_ggml(ggml_context * ctx,
     const int K = (int)w->ne[0];
     static const bool disable_fused =
         std::getenv("SUPERTONIC_DISABLE_FUSED_DEPTHWISE") != nullptr;
-    if (!disable_fused && (K == 3 || K == 5) &&
+    if (!disable_fused && supertonic_use_fused_supertonic_ops() && (K == 3 || K == 5) &&
         x->type == GGML_TYPE_F32 && w->type == GGML_TYPE_F32 &&
         b->type == GGML_TYPE_F32 &&
         x->ne[2] == 1 && x->ne[3] == 1 && w->ne[1] == 1 && w->ne[3] == 1 &&
@@ -219,7 +219,7 @@ ggml_tensor * depthwise_same_ggml(ggml_context * ctx,
 ggml_tensor * layer_norm_ggml(ggml_context * ctx, ggml_tensor * x, ggml_tensor * g, ggml_tensor * b) {
     static const bool disable_fused_layer_norm =
         std::getenv("SUPERTONIC_DISABLE_FUSED_LAYER_NORM") != nullptr;
-    if (!disable_fused_layer_norm &&
+    if (!disable_fused_layer_norm && supertonic_use_fused_supertonic_ops() &&
         x->type == GGML_TYPE_F32 && g->type == GGML_TYPE_F32 && b->type == GGML_TYPE_F32 &&
         x->ne[2] == 1 && x->ne[3] == 1 &&
         g->ne[0] == x->ne[1] && b->ne[0] == x->ne[1] &&

--- a/tts-cpp/src/supertonic_vector_estimator.cpp
+++ b/tts-cpp/src/supertonic_vector_estimator.cpp
@@ -291,7 +291,7 @@ ggml_tensor * edge_clamp_pad_1d(ggml_context * ctx, ggml_tensor * x, int pad_lef
     // SUPERTONIC_DISABLE_FUSED_EDGE_PAD=1.
     static const bool disable_fused_edge_pad =
         std::getenv("SUPERTONIC_DISABLE_FUSED_EDGE_PAD") != nullptr;
-    if (!disable_fused_edge_pad &&
+    if (!disable_fused_edge_pad && supertonic_use_fused_supertonic_ops() &&
         x->type == GGML_TYPE_F32 &&
         x->ne[2] == 1 && x->ne[3] == 1 &&
         ggml_is_contiguous(x)) {
@@ -426,7 +426,7 @@ ggml_tensor * depthwise_same_ggml(ggml_context * ctx,
     // SUPERTONIC_DISABLE_FUSED_DEPTHWISE=1 to force the stock-op chain.
     static const bool disable_fused =
         std::getenv("SUPERTONIC_DISABLE_FUSED_DEPTHWISE") != nullptr;
-    if (!disable_fused && (K == 3 || K == 5) &&
+    if (!disable_fused && supertonic_use_fused_supertonic_ops() && (K == 3 || K == 5) &&
         x->type == GGML_TYPE_F32 && w->type == GGML_TYPE_F32 &&
         b->type == GGML_TYPE_F32 &&
         x->ne[2] == 1 && x->ne[3] == 1 && w->ne[1] == 1 && w->ne[3] == 1 &&
@@ -454,7 +454,7 @@ ggml_tensor * layer_norm_ggml(ggml_context * ctx,
     // a single dispatch.  Override with SUPERTONIC_DISABLE_FUSED_LAYER_NORM=1.
     static const bool disable_fused_layer_norm =
         std::getenv("SUPERTONIC_DISABLE_FUSED_LAYER_NORM") != nullptr;
-    if (!supertonic_use_cpu_custom_ops() && !disable_fused_layer_norm &&
+    if (!supertonic_use_cpu_custom_ops() && supertonic_use_fused_supertonic_ops() && !disable_fused_layer_norm &&
         x->type == GGML_TYPE_F32 && g->type == GGML_TYPE_F32 && b->type == GGML_TYPE_F32 &&
         x->ne[2] == 1 && x->ne[3] == 1 &&
         g->ne[0] == x->ne[1] && b->ne[0] == x->ne[1] &&
@@ -720,7 +720,7 @@ ggml_tensor * bias_gelu_ggml(ggml_context * ctx, ggml_tensor * x, ggml_tensor * 
     // Skipped on CPU custom-op backends (cblas path below is faster).
     static const bool disable_fused_bias_gelu =
         std::getenv("SUPERTONIC_DISABLE_FUSED_BIAS_GELU") != nullptr;
-    if (!use_cpu_custom && !disable_fused_bias_gelu &&
+    if (!use_cpu_custom && supertonic_use_fused_supertonic_ops() && !disable_fused_bias_gelu &&
         x->type == GGML_TYPE_F32 && b->type == GGML_TYPE_F32 &&
         x->ne[2] == 1 && x->ne[3] == 1 &&
         b->ne[0] == x->ne[1] &&
@@ -771,7 +771,7 @@ ggml_tensor * pw2_residual_ggml(ggml_context * ctx,
     // Skipped on CPU custom-op backends (cblas fast path below is faster).
     static const bool disable_fused_pw2_residual =
         std::getenv("SUPERTONIC_DISABLE_FUSED_PW2_RESIDUAL") != nullptr;
-    if (!use_cpu_custom && !disable_fused_pw2_residual &&
+    if (!use_cpu_custom && supertonic_use_fused_supertonic_ops() && !disable_fused_pw2_residual &&
         residual->type == GGML_TYPE_F32 && x->type == GGML_TYPE_F32 &&
         b->type == GGML_TYPE_F32 && gamma->type == GGML_TYPE_F32 &&
         x->ne[2] == 1 && x->ne[3] == 1 &&
@@ -890,7 +890,11 @@ ggml_tensor * vector_convnext_ggml_ct(ggml_context * ctx,
                                       const std::string & p,
                                       ggml_tensor * x_ct,
                                       int dilation) {
-    if (model_prefers_cpu_kernels(model)) {
+    // CPU rounds-trips to the legacy [T,C] block for the AMX-cblas fast path;
+    // backends WITHOUT the fused _ct supertonic ops (Vulkan / OpenCL) must also
+    // take the legacy path, whose helpers carry pure-GGML fallbacks — otherwise
+    // the _ct custom ops below are silently skipped on those backends.
+    if (model_prefers_cpu_kernels(model) || !supertonic_use_fused_supertonic_ops()) {
         // CPU: roundtrip to [T, C], run legacy block (AMX cblas fast path),
         // roundtrip back.  Cheap on CPU because the permute is just a copy.
         ggml_tensor * x_tc = ggml_cont(ctx, ggml_permute(ctx, x_ct, 1, 0, 2, 3));

--- a/tts-cpp/src/supertonic_vocoder.cpp
+++ b/tts-cpp/src/supertonic_vocoder.cpp
@@ -122,7 +122,7 @@ ggml_tensor * causal_replicate_pad_1d(ggml_context * ctx, ggml_tensor * x, int p
     // the stock-ops chain.
     static const bool disable_fused_edge_pad =
         std::getenv("SUPERTONIC_DISABLE_FUSED_EDGE_PAD") != nullptr;
-    if (!disable_fused_edge_pad &&
+    if (!disable_fused_edge_pad && supertonic_use_fused_supertonic_ops() &&
         x->type == GGML_TYPE_F32 &&
         x->ne[2] == 1 && x->ne[3] == 1 &&
         ggml_is_contiguous(x)) {
@@ -377,7 +377,7 @@ ggml_tensor * layer_norm_channel_ggml(ggml_context * ctx,
                                       float eps = 1e-6f) {
     static const bool disable_fused_layer_norm =
         std::getenv("SUPERTONIC_DISABLE_FUSED_LAYER_NORM") != nullptr;
-    if (!disable_fused_layer_norm &&
+    if (!disable_fused_layer_norm && supertonic_use_fused_supertonic_ops() &&
         x->type == GGML_TYPE_F32 && gamma->type == GGML_TYPE_F32 && beta->type == GGML_TYPE_F32 &&
         x->ne[2] == 1 && x->ne[3] == 1 &&
         gamma->ne[0] == x->ne[1] && beta->ne[0] == x->ne[1] &&
@@ -437,7 +437,7 @@ ggml_tensor * convnext_block_ggml(ggml_context * ctx,
     // chain is already the cheapest there.
     static const bool disable_fused_bias_gelu =
         std::getenv("SUPERTONIC_DISABLE_FUSED_BIAS_GELU") != nullptr;
-    if (!disable_fused_bias_gelu &&
+    if (!disable_fused_bias_gelu && supertonic_use_fused_supertonic_ops() &&
         y->type == GGML_TYPE_F32 && w.pw1_w->type == GGML_TYPE_F32 &&
         w.pw1_b->type == GGML_TYPE_F32) {
         y = conv1d_causal_ggml(ctx, y, w.pw1_w, /*b=*/nullptr);
@@ -637,7 +637,13 @@ void build_supertonic_vocoder_cache(vocoder_graph_cache & cache,
     // SUPERTONIC_DISABLE_CT_VOCODER=1.
     static const bool disable_ct_vocoder =
         std::getenv("SUPERTONIC_DISABLE_CT_VOCODER") != nullptr;
-    const bool use_ct_vocoder = !disable_ct_vocoder && !use_cpu_custom;
+    // The _ct block strings the fused supertonic _ct ops together; only run it
+    // when the backend implements them (CPU rounds-trips, Metal native).  On
+    // backends that lack them (Vulkan/OpenCL) take the non-_ct block, whose
+    // helpers carry pure-GGML fallbacks — otherwise the _ct ops are silently
+    // skipped and the vocoder emits garbage.
+    const bool use_ct_vocoder =
+        !disable_ct_vocoder && !use_cpu_custom && supertonic_use_fused_supertonic_ops();
     if (use_ct_vocoder) {
         ggml_tensor * x_ct = ggml_cont(cache.ctx, ggml_permute(cache.ctx, x, 1, 0, 2, 3));
         for (int i = 0; i < 10; ++i) {


### PR DESCRIPTION
## Summary
Makes the tts-cpp suite (Supertonic, Chatterbox T3 + S3Gen) run correctly and
crash-free on Android **Adreno-Vulkan**. S3Gen already worked (its
`run_hift_decode` capability-gate, #36); this PR adds the two missing pieces —
**Supertonic** and the **Chatterbox voice-encoder** — entirely in tts-cpp.
**No ggml change** — qvac-ext-ggml PR #14 (`e6578d01`) is sufficient as-is.

## Root cause (common to both)
ggml-vulkan correctly declares (via `ggml_backend_supports_op`) that it cannot
run certain ops — non-contiguous-src0 unary, tensors larger than Adreno's 128 MB
`maxStorageBufferRange`, the `GGML_OP_SUPERTONIC_*` fused ops. tts-cpp paths that
use single-backend `ggml_backend_graph_compute` bypass that guard, so those ops
are dispatched on Vulkan anyway → garbage audio / DeviceLost.

## Changes
**1. Supertonic — pure-ggml fallback for the fused custom ops.** The
`GGML_OP_SUPERTONIC_*` ops are implemented only in ggml-cpu / ggml-metal. Probe
support once at load (`ggml_backend_supports_op` on a synthetic
`ggml_supertonic_depthwise_1d`) into `backend_supports_fused_supertonic_ops`,
mirror it to a thread_local via `supertonic_op_dispatch_scope`, and gate every
fused-op fast path on it. CPU/Metal keep the fused kernels (zero behavior change);
Vulkan/OpenCL take the existing pure-ggml decomposition (proven correct).

**2. Chatterbox — run the LSTM voice-encoder on CPU.** Its gate tensor is split
into strided views fed to activations (contiguous-only on ggml-vulkan) and it
builds a >128 MB gate matmul (exceeds Adreno's per-descriptor limit). Run this
one-time conditioning step on CPU (the skip-reference path already does). T3,
S3TokenizerV2, CAMPPlus and S3Gen all run on Vulkan unchanged.

## Verification (Adreno 740, iQOO 11)
- Supertonic Vulkan: corr **1.0** vs CPU; ear-verified intelligible.
- S3Gen Vulkan: raw-wav corr **0.9998** vs CPU.
- Chatterbox T3 full pipeline Vulkan: EXIT=0, no DeviceLost; ear-verified
  intelligible on two inputs.
- No-regression: CPU path byte-identical; Supertonic / S3Gen paths unchanged.

## ggml dependency
Builds on qvac-ext-ggml **PR #14** (`e6578d01`) — no change needed there; the
whole suite was verified correct against the clean PR #14 commit.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215009851268650