### PR TITLE
QVAC-19305 tts-cpp: Supertonic v3 support (31 languages, 8-head text attention)

### DIFF
--- a/tts-cpp/CMakeLists.txt
+++ b/tts-cpp/CMakeLists.txt
@@ -816,6 +816,57 @@ if (TTS_CPP_BUILD_TESTS)
     add_supertonic_harness(test-supertonic-vector-trace test/test_supertonic_vector_trace.cpp)
     add_supertonic_harness(test-supertonic-pipeline test/test_supertonic_pipeline.cpp)
     add_supertonic_harness(test-supertonic-engine-cycle test/test_supertonic_engine_cycle.cpp)
+
+    # ------------------------------------------------------------------
+    # QVAC-19305 — Supertonic 3 fixture suite.
+    #
+    # The harnesses above are arch-agnostic: they take (MODEL.gguf REF_DIR)
+    # and don't care which Supertonic generation produced them.  We re-use
+    # those same binaries (via `EXE`) to also run them against a Supertonic
+    # 3 GGUF plus per-language ONNX-Runtime references.  Stage the data with
+    #     scripts/fetch-supertonic3-testdata.sh
+    # (or, once published, the QVAC S3 model registry) and point the build
+    # at it:
+    #     -DTTS_CPP_TEST_MODEL_DIR=<staging>/models
+    #     -DTTS_CPP_TEST_REF_DIR=<staging>/artifacts
+    # Each registration auto-DISABLEs when its GGUF / reference dump is
+    # missing, exactly like the v2 fixtures, so a checkout without the data
+    # still configures cleanly.
+    #
+    # We deliberately run the *Supertonic 2* language set (en/ko/es/pt/fr)
+    # through the v3 model — the v3-only languages are covered by the
+    # model-free test-supertonic-languages unit test — so that both the old
+    # and the new languages get exercised end-to-end on Supertonic 3.
+    set(_tcb_super3_gguf "${TTS_CPP_TEST_MODEL_DIR}/supertonic3.gguf")
+    set(SUPERTONIC3_REF_LANGS en ko es pt fr
+        CACHE STRING "tts-cpp: languages exercised end-to-end against the Supertonic 3 fixture")
+
+    # Per-stage parity on English (the default reference language).  The
+    # full pipeline is covered per-language below, so it is omitted here.
+    foreach (_st3 IN ITEMS
+            test-supertonic-preprocess
+            test-supertonic-text-encoder
+            test-supertonic-vector
+            test-supertonic-vocoder
+            test-supertonic-duration)
+        set(_st3_ref "${TTS_CPP_TEST_REF_DIR}/supertonic3-ref-en")
+        tts_cpp_register_test(${_st3}-v3
+            EXE      ${_st3}
+            LABEL    "fixture"
+            ARGS     "${_tcb_super3_gguf}" "${_st3_ref}"
+            REQUIRES "${_tcb_super3_gguf}" "${_st3_ref}/noise.npy")
+    endforeach()
+
+    # Full-pipeline parity per language — old + new languages on Supertonic 3.
+    foreach (_st3lang IN LISTS SUPERTONIC3_REF_LANGS)
+        set(_st3_ref "${TTS_CPP_TEST_REF_DIR}/supertonic3-ref-${_st3lang}")
+        tts_cpp_register_test(test-supertonic-pipeline-v3-${_st3lang}
+            EXE      test-supertonic-pipeline
+            LABEL    "fixture"
+            ARGS     "${_tcb_super3_gguf}" "${_st3_ref}"
+            REQUIRES "${_tcb_super3_gguf}" "${_st3_ref}/noise.npy")
+    endforeach()
+
     # OpenCL optimization audit follow-up harnesses (F1–F11).
     add_supertonic_harness(test-supertonic-load-caches    test/test_supertonic_load_caches.cpp)
     add_supertonic_harness(test-supertonic-graph-rewrites test/test_supertonic_graph_rewrites.cpp)

--- a/tts-cpp/CMakeLists.txt
+++ b/tts-cpp/CMakeLists.txt
@@ -1016,6 +1016,21 @@ if (TTS_CPP_BUILD_TESTS)
     tts_cpp_apply_ccache(test-supertonic-kv-attn-type-api)
     tts_cpp_register_test(test-supertonic-kv-attn-type-api LABEL "unit")
 
+    # QVAC-19305 — Supertonic v3 language-coverage contract.
+    # Pins the runtime language validator against the v3 bundle
+    # (31 languages + the language-agnostic `na`) shipped in the
+    # GGUF `supertonic.languages` array; asserts the built-in
+    # fallback still only accepts the legacy v1/v2 5-language set.
+    # CPU-only unit test (no model); an optional fixture sub-test
+    # cross-checks a loaded model's advertised languages when a
+    # GGUF path is passed as argv[1].
+    add_executable(test-supertonic-languages
+        test/test_supertonic_languages.cpp)
+    target_link_libraries(test-supertonic-languages PRIVATE tts-cpp)
+    target_include_directories(test-supertonic-languages PRIVATE ggml/include src include)
+    tts_cpp_apply_ccache(test-supertonic-languages)
+    tts_cpp_register_test(test-supertonic-languages LABEL "unit")
+
     # QVAC-18605 round 7 — Vulkan env-var passthrough mechanism
     # (EngineOptions::vulkan_env_overrides + apply_vulkan_env_overrides
     # public helper).  Tests cover: SFINAE field existence, empty-

--- a/tts-cpp/scripts/convert-supertonic2-to-gguf.py
+++ b/tts-cpp/scripts/convert-supertonic2-to-gguf.py
@@ -448,6 +448,109 @@ def materialize_intermediates(model_path: Path, names: list[str]) -> dict[str, n
     return {nm: as_contiguous(np.asarray(arr)) for nm, arr in zip(names, outs)}
 
 
+def extract_text_convnext_dilations(onnx_path: Path) -> list[int]:
+    """Per-block dwconv dilations of the text-encoder ConvNeXt stack.
+
+    Supertonic 3 introduced a *dilated* text-encoder ConvNeXt (dilation grows
+    per block, e.g. 1,1,2,2,4,4) whereas v1/v2 used dilation 1 everywhere.  The
+    dilation is a structural parameter (not a weight), so the runtime cannot
+    recover it from the tensors alone; we read it from the ONNX `Conv` attrs at
+    convert time and stash it in metadata.  Blocks are ordered by the numeric
+    index in `/text_encoder/convnext/convnext.<i>/dwconv/Conv`.
+    """
+    model = onnx.load(str(onnx_path), load_external_data=False)
+    prefix = "/text_encoder/convnext/convnext."
+    suffix = "/dwconv/Conv"
+    found: dict[int, int] = {}
+    for node in model.graph.node:
+        if node.op_type != "Conv" or not node.name.startswith(prefix) or not node.name.endswith(suffix):
+            continue
+        try:
+            idx = int(node.name[len(prefix):-len(suffix)])
+        except ValueError:
+            continue
+        dil = 1
+        for attr in node.attribute:
+            if attr.name == "dilations" and len(attr.ints) >= 1:
+                dil = int(attr.ints[0])
+        found[idx] = dil
+    if not found:
+        return []
+    return [found[i] for i in sorted(found)]
+
+
+def extract_cfg_scales(onnx_path: Path) -> tuple[float, float] | None:
+    """Classifier-free-guidance scales baked into the vector estimator.
+
+    Supertonic 3's vector_estimator runs the field on a batch-2 input
+    (conditional + unconditional, the latter fed learned `uncond_masker`
+    null tokens) and forms the velocity as
+    `v = cond_scale * v_cond - uncond_scale * v_uncond`
+    (e.g. 4*cond - 3*uncond, i.e. guidance scale 4).  v1/v2 have no such
+    combination.  We locate the two scalar `Mul` constants that scale the
+    conditional/unconditional `Slice`s of `proj_out` and return them so the
+    runtime can replicate the guidance.  Returns None when the graph has no
+    CFG (no `uncond_masker`), so the runtime falls back to a single pass.
+    """
+    model = onnx.load(str(onnx_path), load_external_data=False)
+    has_uncond = any("uncond_masker" in i.name for i in model.graph.initializer)
+    if not has_uncond:
+        return None
+    prod = {o: n for n in model.graph.node for o in n.output}
+
+    def scalar_const(name: str):
+        n = prod.get(name)
+        if n is not None and n.op_type == "Constant":
+            for a in n.attribute:
+                if a.name == "value":
+                    arr = onnx.numpy_helper.to_array(a.t)
+                    if arr.size == 1:
+                        return float(arr.reshape(-1)[0])
+        for i in model.graph.initializer:
+            if i.name == name:
+                arr = onnx.numpy_helper.to_array(i)
+                if arr.size == 1:
+                    return float(arr.reshape(-1)[0])
+        return None
+
+    # Find Sub = Mul_cond - Mul_uncond where each Mul scales a Slice by a scalar.
+    for n in model.graph.node:
+        if n.op_type != "Sub":
+            continue
+        muls = [prod.get(i) for i in n.input]
+        if len(muls) != 2 or any(m is None or m.op_type != "Mul" for m in muls):
+            continue
+        scales = []
+        slice_starts = []
+        ok = True
+        for m in muls:
+            scalar = None
+            slice_node = None
+            for i in m.input:
+                v = scalar_const(i)
+                if v is not None:
+                    scalar = v
+                p = prod.get(i)
+                if p is not None and p.op_type == "Slice":
+                    slice_node = p
+            if scalar is None or slice_node is None:
+                ok = False
+                break
+            scales.append(scalar)
+            # Slice start (input[1]) tells cond (start 0) from uncond (start B).
+            start = scalar_const(slice_node.input[1]) if len(slice_node.input) > 1 else None
+            slice_starts.append(start)
+        if not ok:
+            continue
+        # cond = the Mul whose Slice starts at 0; uncond = the other.
+        if slice_starts[0] == 0 or (slice_starts[1] not in (0, None)):
+            cond_scale, uncond_scale = scales[0], scales[1]
+        else:
+            cond_scale, uncond_scale = scales[1], scales[0]
+        return (cond_scale, uncond_scale)
+    return None
+
+
 def add_json_metadata(writer: "gguf.GGUFWriter", prefix: str, data: dict) -> None:
     writer.add_string(prefix, json.dumps(data, ensure_ascii=False, separators=(",", ":")))
 
@@ -503,6 +606,26 @@ def main() -> int:
     # tts.json omits the key.
     text_cond = cfg.get("ttl", {}).get("vector_field", {}).get("main_blocks", {}).get("text_cond_layer", {})
     writer.add_uint32("supertonic.vector_text_attn_heads", int(text_cond.get("n_heads", 4)))
+    # Per-block dwconv dilations of the text-encoder ConvNeXt stack.  v1/v2 use
+    # dilation 1 everywhere; Supertonic 3 dilates it (e.g. 1,1,2,2,4,4).  The
+    # runtime reads this array and applies it per block; bundles without the key
+    # (older conversions) default to dilation 1, preserving v1/v2 behaviour.
+    text_convnext_dilations = extract_text_convnext_dilations(args.onnx_dir / "text_encoder.onnx")
+    if text_convnext_dilations:
+        writer.add_array(
+            "supertonic.text_convnext_dilations",
+            [int(d) for d in text_convnext_dilations],
+        )
+        print(f"text-encoder ConvNeXt dilations: {text_convnext_dilations}")
+    # Classifier-free guidance scales baked into the v3 vector estimator
+    # (`v = cond_scale*v_cond - uncond_scale*v_uncond`).  Absent on v1/v2,
+    # where the runtime defaults to cond_scale=1, uncond_scale=0 (no guidance).
+    cfg_scales = extract_cfg_scales(args.onnx_dir / "vector_estimator.onnx")
+    if cfg_scales is not None:
+        cond_scale, uncond_scale = cfg_scales
+        writer.add_float32("supertonic.cfg_cond_scale", float(cond_scale))
+        writer.add_float32("supertonic.cfg_uncond_scale", float(uncond_scale))
+        print(f"vector-estimator CFG scales: cond={cond_scale} uncond={uncond_scale}")
     wrap_mode = "none" if args.no_language_wrap else (args.language_wrap_mode or ("none" if args.arch == "supertonic" else "open_close"))
     default_steps = args.default_steps if args.default_steps is not None else 5
 

--- a/tts-cpp/scripts/convert-supertonic2-to-gguf.py
+++ b/tts-cpp/scripts/convert-supertonic2-to-gguf.py
@@ -608,6 +608,35 @@ def main() -> int:
                     stage_aliases[f"{stage}:{canon_name}"] = f"{stage}:{cand}"
                     break
 
+        # QVAC-19305 — convert-time guarantee that every vector-estimator
+        # bridge the runtime depends on is resolvable.  The bridge maps each
+        # v2 logical id (`onnx::MatMul_<v2id>`) to a weight via its stable
+        # canonical (PyTorch) name, and that canonical name is recovered from
+        # the MatMul's adjacent bias-`Add` (see `canonical_source_name`).  If a
+        # v3 export drops the adjacent bias for a projection (e.g. a bias-free
+        # `W_key`), the canonical lookup misses, no bridge alias is emitted,
+        # and the runtime would later fail to bind `onnx::MatMul_<v2id>`.  A
+        # logical id is resolvable when it is either emitted as a primary
+        # source (the v2 case, where the id *is* the weight's name) or
+        # recorded as a bridge alias (the v3 case).  Fail loudly here — naming
+        # the offending ids — rather than shipping an unloadable GGUF.
+        missing_bridges = sorted(
+            logical
+            for canon, logical in CANONICAL_TO_LOGICAL.get(stage, {}).items()
+            if logical not in emitted_sources
+            and f"{stage}:{logical}" not in stage_aliases
+        )
+        if missing_bridges:
+            raise RuntimeError(
+                f"{stage}: {len(missing_bridges)} vector-estimator bridge "
+                f"alias(es) could not be derived: {missing_bridges}.  These "
+                f"weights are bound by their v2 logical id at runtime; the "
+                f"likely cause is a projection whose canonical name could not "
+                f"be recovered (e.g. a MatMul with no adjacent bias-Add in "
+                f"this export).  Extend canonical_source_name / "
+                f"CANONICAL_TO_LOGICAL to cover it before converting."
+            )
+
         for alias_key, target_key in stage_aliases.items():
             source_aliases.append(alias_key)
             source_alias_targets.append(target_key)

--- a/tts-cpp/scripts/convert-supertonic2-to-gguf.py
+++ b/tts-cpp/scripts/convert-supertonic2-to-gguf.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Convert official Supertonic 2 ONNX/assets into a single GGUF file.
+"""Convert official Supertonic (v1/v2/v3) ONNX/assets into a single GGUF file.
 
 This is intentionally model-specific.  The GGUF stores every ONNX initializer
 and tensor-valued Constant under short ggml-safe names, plus metadata arrays
@@ -54,11 +54,12 @@ def parse_args() -> argparse.Namespace:
                    help="Directory containing unicode_indexer.json and voice_styles/. "
                         "Defaults to --onnx-dir if present, otherwise ../../assets relative to --onnx-dir.")
     p.add_argument("--out", type=Path, default=Path("models/supertonic2.gguf"))
-    p.add_argument("--arch", default="supertonic2", choices=("supertonic", "supertonic2"),
-                   help="Model family metadata. Use 'supertonic' for the English-only HF bundle.")
+    p.add_argument("--arch", default="supertonic2", choices=("supertonic", "supertonic2", "supertonic3"),
+                   help="Model family metadata. Use 'supertonic' for the English-only HF bundle, "
+                        "'supertonic2' for the 5-language bundle, 'supertonic3' for the 31-language bundle.")
     p.add_argument("--repo-id", default=None,
                    help="Hugging Face repo to download when --onnx-dir is omitted. "
-                        "Defaults to Supertone/supertonic-2 or Supertone/supertonic based on --arch.")
+                        "Defaults to Supertone/supertonic, -2, or -3 based on --arch.")
     p.add_argument("--download-dir", type=Path, default=None,
                    help="Optional local directory for the Hugging Face snapshot download.")
     p.add_argument("--hf-token", default=None, help="Optional Hugging Face token.")
@@ -86,7 +87,27 @@ def parse_args() -> argparse.Namespace:
 
 
 def default_repo_for_arch(arch: str) -> str:
-    return "Supertone/supertonic" if arch == "supertonic" else "Supertone/supertonic-2"
+    return {
+        "supertonic": "Supertone/supertonic",
+        "supertonic2": "Supertone/supertonic-2",
+        "supertonic3": "Supertone/supertonic-3",
+    }[arch]
+
+
+# Supertonic language coverage per family.  The runtime validates user-supplied
+# language codes against the GGUF `supertonic.languages` array, so this list is
+# the source of truth for which `<lang>` wrappers are accepted.  v3 adds the
+# language-agnostic `na` code (README: pass lang="na" when the input language is
+# unknown) alongside the 31 supported languages.
+ARCH_LANGUAGES = {
+    "supertonic": ["en"],
+    "supertonic2": ["en", "ko", "es", "pt", "fr"],
+    "supertonic3": [
+        "ar", "bg", "hr", "cs", "da", "nl", "en", "et", "fi", "fr", "de", "el",
+        "hi", "hu", "id", "it", "ja", "ko", "lv", "lt", "pl", "pt", "ro", "ru",
+        "sk", "sl", "es", "sv", "tr", "uk", "vi", "na",
+    ],
+}
 
 
 def download_hf_snapshot(repo_id: str,
@@ -232,8 +253,7 @@ def tensor_from_attribute(attr: onnx.AttributeProto) -> np.ndarray | None:
     return None
 
 
-def iter_onnx_tensors(model_path: Path) -> Iterable[tuple[str, np.ndarray]]:
-    model = onnx.load(str(model_path), load_external_data=True)
+def iter_onnx_tensors_from_model(model: "onnx.ModelProto") -> Iterable[tuple[str, np.ndarray]]:
     seen: set[str] = set()
 
     for init in model.graph.initializer:
@@ -259,6 +279,173 @@ def iter_onnx_tensors(model_path: Path) -> Iterable[tuple[str, np.ndarray]]:
             seen.add(out_name)
             yield out_name, as_contiguous(arr)
             break
+
+
+def iter_onnx_tensors(model_path: Path) -> Iterable[tuple[str, np.ndarray]]:
+    yield from iter_onnx_tensors_from_model(onnx.load(str(model_path), load_external_data=True))
+
+
+# ---------------------------------------------------------------------------
+# Cross-version stable naming (Supertonic 3 support)
+# ---------------------------------------------------------------------------
+#
+# ONNX export auto-numbers the weights that have no PyTorch parameter name —
+# linear-layer weights surface as `onnx::MatMul_<NNNN>`, conv/PReLU weights as
+# `onnx::Conv_<NNNN>` / `onnx::PRelu_<NNNN>`.  Those numeric ids are assigned by
+# the exporter and are completely renumbered between Supertonic 2 and 3, so a
+# runtime that hard-codes `onnx::MatMul_3095` cannot bind the same logical
+# weight across families.  v3 additionally prefixes every node/initializer with
+# the top-level module name (`vector_estimator.tts...`, `/vector_estimator/...`).
+#
+# To make the runtime version-independent we emit, for every tensor, a stable
+# *canonical* alias derived from structure that is identical across families:
+#   - dotted PyTorch paths     -> strip everything before `tts.`
+#   - auto MatMul/Gemm weights -> the adjacent bias' PyTorch path with
+#                                 `.bias` -> `.weight` (MatMul -> Add(bias))
+#   - auto Conv/PRelu weights  -> the consuming node's (stable) name + input idx
+# The GGUF stores these as `supertonic.source_aliases` (canonical key) ->
+# `supertonic.source_alias_targets` (the primary `<stage>:<onnx-name>` source);
+# the loader registers both keys against the same tensor.  See the C++ loader.
+
+
+def _norm_tts(name: str) -> str:
+    i = name.find("tts.")
+    return name[i:] if i >= 0 else name
+
+
+def build_graph_index(model: "onnx.ModelProto") -> tuple[set[str], dict[str, list[tuple["onnx.NodeProto", int]]]]:
+    init_names = {i.name for i in model.graph.initializer}
+    consumers: dict[str, list[tuple["onnx.NodeProto", int]]] = {}
+    for node in model.graph.node:
+        for idx, inp in enumerate(node.input):
+            if inp:
+                consumers.setdefault(inp, []).append((node, idx))
+    return init_names, consumers
+
+
+def canonical_source_name(name: str,
+                          init_names: set[str],
+                          consumers: dict[str, list[tuple["onnx.NodeProto", int]]]) -> str | None:
+    """Stable, cross-family alias for `name`, or None when no alias is needed."""
+    if "tts." in name:
+        canon = _norm_tts(name)
+        return canon if canon != name else None
+    if "onnx::" in name and ("MatMul_" in name or "Gemm_" in name):
+        for node, _ in consumers.get(name, []):
+            if node.op_type not in ("MatMul", "Gemm"):
+                continue
+            out = node.output[0] if node.output else ""
+            for cons, _ in consumers.get(out, []):
+                if cons.op_type == "Add":
+                    for inp in cons.input:
+                        if inp in init_names and inp.endswith(".bias") and "onnx::" not in inp:
+                            return _norm_tts(inp[: -len(".bias")] + ".weight")
+            return f"node:{node.name}#W"
+        return None
+    if "onnx::" in name and ("Conv_" in name or "PRelu_" in name):
+        for node, idx in consumers.get(name, []):
+            return f"node:{node.name}#{idx}"
+        return None
+    return None
+
+
+# Runtime "logical id" contract (bridge aliases).
+#
+# The C++ vector-estimator path references its ~36 linear weights by the
+# Supertonic-2 ONNX auto-id (`vector_estimator:onnx::MatMul_<id>`).  Those ids
+# are renumbered in v3, so for any non-v2 bundle we additionally emit an alias
+# from the *v2 logical id* to the actual weight, keyed off the stable canonical
+# (PyTorch) name.  This keeps the delicate vector-estimator scalar + graph
+# paths byte-identical across families (only the genuine head-count change is
+# threaded in code) while still deriving everything from stable structure.
+def _build_ve_canonical_to_logical() -> dict[str, str]:
+    pre = "tts.ttl.vector_field.main_blocks."
+    t_linear = [3095, 3140, 3185, 3230]
+    attn_q = [3101, 3146, 3191, 3236]
+    attn_out = [3110, 3155, 3200, 3245]
+    style_q = [3116, 3161, 3206, 3251]
+    style_out = [3119, 3164, 3209, 3254]
+    table: dict[str, str] = {}
+    for g in range(4):
+        table[f"{pre}{1 + 6 * g}.linear.linear.weight"] = f"onnx::MatMul_{t_linear[g]}"
+        ab = 3 + 6 * g
+        for off, role in enumerate(("W_query", "W_key", "W_value")):
+            table[f"{pre}{ab}.attn.{role}.linear.weight"] = f"onnx::MatMul_{attn_q[g] + off}"
+        table[f"{pre}{ab}.attn.out_fc.linear.weight"] = f"onnx::MatMul_{attn_out[g]}"
+        sb = 5 + 6 * g
+        for off, role in enumerate(("W_query", "W_key", "W_value")):
+            table[f"{pre}{sb}.attention.{role}.linear.weight"] = f"onnx::MatMul_{style_q[g] + off}"
+        table[f"{pre}{sb}.attention.out_fc.linear.weight"] = f"onnx::MatMul_{style_out[g]}"
+    return table
+
+
+CANONICAL_TO_LOGICAL: dict[str, dict[str, str]] = {
+    "vector_estimator": _build_ve_canonical_to_logical(),
+}
+
+
+# Input-independent intermediate constants that the runtime fetches by their
+# ONNX value name.  In Supertonic 2 the ONNX exporter constant-folded these
+# into initializers / Constant nodes (so `iter_onnx_tensors` already emits
+# them); in v3 they remain *live* graph outputs and must be materialised by
+# running the input-independent subgraph once at convert time.  Validated
+# input-independent (identical for arbitrary dummy inputs) — see QVAC-19305.
+MATERIALIZE_INTERMEDIATES: dict[str, list[str]] = {
+    "text_encoder": [
+        "/speech_prompted_text_encoder/attention1/tanh/Tanh_output_0",
+        "/speech_prompted_text_encoder/attention2/tanh/Tanh_output_0",
+    ],
+}
+
+# Intermediate constants whose ONNX name carries the v3 module prefix.  Each
+# entry maps a canonical name (the one the runtime asks for) to the candidate
+# source names that may carry the data across families; the converter aliases
+# whichever candidate it actually emitted.
+INTERMEDIATE_ALIASES: dict[str, list[tuple[str, list[str]]]] = {
+    "vector_estimator": [
+        ("/Expand_output_0", ["/Expand_output_0", "/vector_estimator/Expand_output_0"]),
+    ],
+}
+
+
+def make_dummy_feeds(model: "onnx.ModelProto") -> dict[str, np.ndarray]:
+    """Build zero/one dummy inputs for every graph input (symbolic dims -> small
+    constants).  Only used to evaluate input-independent subgraphs, so the
+    concrete values are irrelevant."""
+    elem_to_np = {
+        onnx.TensorProto.FLOAT: np.float32,
+        onnx.TensorProto.DOUBLE: np.float64,
+        onnx.TensorProto.INT64: np.int64,
+        onnx.TensorProto.INT32: np.int32,
+        onnx.TensorProto.BOOL: np.bool_,
+    }
+    feeds: dict[str, np.ndarray] = {}
+    for inp in model.graph.input:
+        tt = inp.type.tensor_type
+        dims = [d.dim_value if d.HasField("dim_value") else 4 for d in tt.shape.dim]
+        npdt = elem_to_np.get(tt.elem_type, np.float32)
+        feeds[inp.name] = np.ones(tuple(dims) if dims else (1,), dtype=npdt)
+    return feeds
+
+
+def materialize_intermediates(model_path: Path, names: list[str]) -> dict[str, np.ndarray]:
+    """Run `model_path` once with dummy inputs, capturing `names` (assumed
+    input-independent).  Returns {name: array}.  Requires onnxruntime."""
+    try:
+        import onnxruntime as ort  # noqa: WPS433 (lazy: only needed for v3)
+    except ImportError as exc:  # pragma: no cover - user environment guard
+        raise SystemExit(
+            "error: materialising Supertonic 3 intermediate constants needs "
+            "'onnxruntime'; install with `pip install onnxruntime`."
+        ) from exc
+    model = onnx.load(str(model_path), load_external_data=True)
+    existing = {o.name for o in model.graph.output}
+    for nm in names:
+        if nm not in existing:
+            model.graph.output.append(onnx.helper.make_empty_tensor_value_info(nm))
+    sess = ort.InferenceSession(model.SerializeToString(), providers=["CPUExecutionProvider"])
+    outs = sess.run(names, make_dummy_feeds(model))
+    return {nm: as_contiguous(np.asarray(arr)) for nm, arr in zip(names, outs)}
 
 
 def add_json_metadata(writer: "gguf.GGUFWriter", prefix: str, data: dict) -> None:
@@ -288,8 +475,13 @@ def main() -> int:
     unicode_indexer = np.asarray(json.loads(unicode_path.read_text()), dtype=np.int32)
 
     reference_repo = args.reference_repo or repo_id
+    arch_display = {
+        "supertonic": "Supertonic",
+        "supertonic2": "Supertonic 2",
+        "supertonic3": "Supertonic 3",
+    }[args.arch]
     writer = gguf.GGUFWriter(str(args.out), args.arch)
-    writer.add_name("Supertonic" if args.arch == "supertonic" else "Supertonic 2")
+    writer.add_name(arch_display)
     writer.add_description(f"{reference_repo} ONNX weights/assets converted for a model-specific ggml runtime.")
     writer.add_string("supertonic.arch", args.arch)
     writer.add_string("supertonic.reference_repo", reference_repo)
@@ -304,6 +496,13 @@ def main() -> int:
         "supertonic.latent_channels",
         int(cfg["ttl"]["latent_dim"]) * int(cfg["ttl"]["chunk_compress_factor"]),
     )
+    # Vector-estimator text cross-attention head count.  This is the only
+    # internal topology dimension that differs across families (v1/v2: 4,
+    # v3: 8 with the same head_dim=64), so the runtime reads it from metadata
+    # instead of branching on arch.  Falls back to 4 for older bundles whose
+    # tts.json omits the key.
+    text_cond = cfg.get("ttl", {}).get("vector_field", {}).get("main_blocks", {}).get("text_cond_layer", {})
+    writer.add_uint32("supertonic.vector_text_attn_heads", int(text_cond.get("n_heads", 4)))
     wrap_mode = "none" if args.no_language_wrap else (args.language_wrap_mode or ("none" if args.arch == "supertonic" else "open_close"))
     default_steps = args.default_steps if args.default_steps is not None else 5
 
@@ -311,7 +510,7 @@ def main() -> int:
     writer.add_float32("supertonic.default_speed", args.default_speed)
     writer.add_uint32("supertonic.language_wrap", 0 if wrap_mode == "none" else 1)
     writer.add_string("supertonic.language_wrap_mode", wrap_mode)
-    writer.add_array("supertonic.languages", ["en", "ko", "es", "pt", "fr"])
+    writer.add_array("supertonic.languages", ARCH_LANGUAGES[args.arch])
     add_json_metadata(writer, "supertonic.tts_json", cfg)
 
     writer.add_tensor("supertonic/unicode_indexer", unicode_indexer)
@@ -339,28 +538,91 @@ def main() -> int:
     per_stage_counts: dict[str, int] = {}
     total_bytes = 0
 
+    # Stable cross-family aliases: `<stage>:<canonical>` -> `<stage>:<onnx-name>`.
+    source_aliases: list[str] = []
+    source_alias_targets: list[str] = []
+
+    def emit_tensor(stage: str, source_name: str, arr: np.ndarray, count: int) -> None:
+        nonlocal total_bytes
+        short_name = f"supertonic/{stage}/t{count:04d}"
+        source_key = f"{stage}:{source_name}"
+        stored, raw_shape, raw_dtype = prepare_weight_tensor(arr, args.ftype)
+        writer.add_tensor(short_name, stored, raw_shape=raw_shape, raw_dtype=raw_dtype)
+        tensor_names.append(short_name)
+        source_names.append(source_key)
+        tensor_shapes.append(json.dumps(list(arr.shape), separators=(",", ":")))
+        tensor_dtypes.append(str(raw_dtype.name if raw_dtype is not None else stored.dtype))
+        tensor_hashes.append(tensor_sha256(stored))
+        total_bytes += stored.nbytes
+
     for stage, filename in STAGES:
+        model = onnx.load(str(args.onnx_dir / filename), load_external_data=True)
+        init_names, consumers = build_graph_index(model)
+        # canonical alias -> primary source key (for collision detection).
+        stage_aliases: dict[str, str] = {}
+        emitted_sources: set[str] = set()
         count = 0
-        for source_name, arr in iter_onnx_tensors(args.onnx_dir / filename):
-            short_name = f"supertonic/{stage}/t{count:04d}"
-            source_key = f"{stage}:{source_name}"
-            stored, raw_shape, raw_dtype = prepare_weight_tensor(arr, args.ftype)
-            writer.add_tensor(short_name, stored, raw_shape=raw_shape, raw_dtype=raw_dtype)
-            tensor_names.append(short_name)
-            source_names.append(source_key)
-            tensor_shapes.append(json.dumps(list(arr.shape), separators=(",", ":")))
-            tensor_dtypes.append(str(raw_dtype.name if raw_dtype is not None else stored.dtype))
-            tensor_hashes.append(tensor_sha256(stored))
-            total_bytes += stored.nbytes
+        for source_name, arr in iter_onnx_tensors_from_model(model):
+            emit_tensor(stage, source_name, arr, count)
+            emitted_sources.add(source_name)
+            canon = canonical_source_name(source_name, init_names, consumers)
+            target_key = f"{stage}:{source_name}"
+
+            def _record_alias(alias_name: str) -> None:
+                if alias_name == source_name:
+                    return
+                alias_key = f"{stage}:{alias_name}"
+                if alias_key in stage_aliases and stage_aliases[alias_key] != target_key:
+                    print(f"  WARNING: alias collision {alias_key}: "
+                          f"{stage_aliases[alias_key]} vs {target_key} (keeping first)")
+                elif alias_key not in stage_aliases:
+                    stage_aliases[alias_key] = target_key
+
+            if canon is not None:
+                _record_alias(canon)
+                # Bridge alias: map the v2 logical id to this weight so the
+                # runtime's hard-coded `onnx::MatMul_<v2id>` references resolve
+                # against a renumbered (v3) export.
+                logical = CANONICAL_TO_LOGICAL.get(stage, {}).get(canon)
+                if logical is not None:
+                    _record_alias(logical)
             count += 1
+
+        # Materialise input-independent intermediates that v3 leaves live.
+        for nm in MATERIALIZE_INTERMEDIATES.get(stage, []):
+            if nm in emitted_sources:
+                continue
+            print(f"  materialising input-independent constant {stage}:{nm}")
+            for mat_name, mat_arr in materialize_intermediates(args.onnx_dir / filename, [nm]).items():
+                emit_tensor(stage, mat_name, mat_arr, count)
+                emitted_sources.add(mat_name)
+                count += 1
+
+        # Module-prefixed intermediates: alias the canonical name the runtime
+        # asks for to whichever candidate source we actually emitted.
+        for canon_name, candidates in INTERMEDIATE_ALIASES.get(stage, []):
+            if canon_name in emitted_sources:
+                continue  # already present under the canonical name (v2)
+            for cand in candidates:
+                if cand in emitted_sources:
+                    stage_aliases[f"{stage}:{canon_name}"] = f"{stage}:{cand}"
+                    break
+
+        for alias_key, target_key in stage_aliases.items():
+            source_aliases.append(alias_key)
+            source_alias_targets.append(target_key)
+
         per_stage_counts[stage] = count
-        print(f"{stage:16s} {count:5d} tensors")
+        print(f"{stage:16s} {count:5d} tensors  ({len(stage_aliases)} stable aliases)")
 
     writer.add_array("supertonic.tensor_names", tensor_names)
     writer.add_array("supertonic.source_names", source_names)
     writer.add_array("supertonic.tensor_shapes", tensor_shapes)
     writer.add_array("supertonic.tensor_dtypes", tensor_dtypes)
     writer.add_array("supertonic.tensor_sha256", tensor_hashes)
+    if source_aliases:
+        writer.add_array("supertonic.source_aliases", source_aliases)
+        writer.add_array("supertonic.source_alias_targets", source_alias_targets)
     for stage, count in per_stage_counts.items():
         writer.add_uint32(f"supertonic.{stage}.tensor_count", count)
 

--- a/tts-cpp/scripts/requantize-gguf.py
+++ b/tts-cpp/scripts/requantize-gguf.py
@@ -169,6 +169,93 @@ _QUANT_TYPE = {
 }
 
 
+# Supertonic (v1/v2/v3) keep-as-source-dtype roster.  Unlike the chatterbox
+# _DENY_SUBSTRINGS roster above, Supertonic tensors are stored under OPAQUE
+# names (`supertonic/<stage>/tNNNN`) plus the descriptive `voices/<id>/ttl`,
+# so a substring deny against the storage name catches nothing.  Instead we
+# resolve each opaque name back to its *logical* PyTorch/ONNX source name via
+# the converter-emitted alias arrays (supertonic.source_names /
+# .tensor_names / .source_aliases / .source_alias_targets) and deny by
+# logical-name substring.
+#
+# The roster targets exactly the tensors the C++ loader reads as **raw F32**
+# (uploaded as graph inputs / constants, NOT consumed through ggml's
+# dequantizing matmul/get_rows paths).  Block-quantizing those reinterprets
+# Q4/Q8 bytes as floats -> NaN -> a crash (q4_0) or decorrelated audio
+# (q8_0).  The genuine projection weights (`onnx::MatMul_*`, `*.linear.weight`)
+# stay quantizable because ggml dequantizes them in-op.
+#
+# Why this only began biting in v3: the CFG `uncond_masker.*_special_token`
+# tensors are [50, 256] (last-dim 256 % 32 == 0 -> quantizable) AND read raw,
+# and they simply do not exist in v1/v2 (no classifier-free guidance there).
+_SUPERTONIC_KEEP_F32_LOGICAL = (
+    "Expand_output",        # vector_estimator style-key constant (/Expand_output_0)
+    "uncond_masker",        # v3 CFG null text/style tokens (read raw)
+    "special_token",        # ditto (style_key/value/text_special_token)
+    "char_embedder",        # text/duration char embedding tables
+    "text_embedder",        # embedder wrappers
+    "sentence_token",       # duration sentence-encoder learned token
+    "style_key",            # style-token-layer learned key (read raw)
+    "style_value",
+    "style_token",
+    "rope",                 # rotary position frequencies
+    "theta",
+)
+# Storage-name (opaque) substrings — for tensors with no logical alias.
+_SUPERTONIC_KEEP_F32_STORAGE = (
+    "/voices/",             # per-voice conditioning embeddings (ttl), read raw
+    # The duration predictor runs as a scalar CPU continuation that reads
+    # EVERY weight through `read_f32` / `cached_read_f32` (a raw F32 byte
+    # copy, no in-op dequant), so any block-quantized duration weight is
+    # reinterpreted as floats -> SIGBUS (q4_0) / corrupted phoneme timings
+    # -> fully decorrelated audio (q8_0).  The stage is tiny, so keeping it
+    # at source dtype costs almost nothing.  (The text/vector matmuls stay
+    # quantizable: those flow through ggml mul_mat, which dequantizes in-op.)
+    "supertonic/duration/",
+)
+
+
+def build_supertonic_keep_f32(src: gguf.GGUFReader) -> set[str]:
+    """Resolve the Supertonic raw-read roster to a set of opaque storage
+    tensor names that must NOT be quantized.  Returns empty set when the
+    alias metadata is absent (non-Supertonic GGUF)."""
+    def _arr(key: str) -> list[str]:
+        fld = src.fields.get(key)
+        if fld is None:
+            return []
+        return [bytes(fld.parts[i]).decode("utf-8", "replace") for i in fld.data]
+
+    source_names = _arr("supertonic.source_names")
+    tensor_names = _arr("supertonic.tensor_names")
+    alias_names = _arr("supertonic.source_aliases")
+    alias_targets = _arr("supertonic.source_alias_targets")
+
+    # opaque storage name -> set of logical source names pointing at it.
+    storage_to_logical: dict[str, set[str]] = {}
+    for logical, storage in zip(source_names, tensor_names):
+        storage_to_logical.setdefault(storage, set()).add(logical)
+    # aliases map an extra logical name onto an existing source name; chase
+    # them to the same storage tensor so e.g. `...W_key.linear.weight` and its
+    # `onnx::MatMul_*` bridge alias both resolve.
+    logical_to_storage: dict[str, str] = {
+        logical: storage for logical, storage in zip(source_names, tensor_names)
+    }
+    for alias, target in zip(alias_names, alias_targets):
+        storage = logical_to_storage.get(target)
+        if storage is not None:
+            storage_to_logical.setdefault(storage, set()).add(alias)
+
+    keep: set[str] = set()
+    for storage, logicals in storage_to_logical.items():
+        if any(any(p in lg for p in _SUPERTONIC_KEEP_F32_LOGICAL) for lg in logicals):
+            keep.add(storage)
+    # Storage-name fallback (voices have no logical alias).
+    for t in src.tensors:
+        if any(p in t.name for p in _SUPERTONIC_KEEP_F32_STORAGE):
+            keep.add(t.name)
+    return keep
+
+
 def should_quantize(name: str, shape: tuple[int, ...], qtype: gguf.GGMLQuantizationType) -> bool:
     # Keep tiny tensors at full precision.
     n_elements = 1
@@ -243,6 +330,14 @@ def main() -> int:
     if arch is not None:
         arch_name = bytes(arch.parts[arch.data[0]]).decode("utf-8")
 
+    # Supertonic stores weights under opaque `tNNNN` names; resolve the
+    # raw-read roster via the alias arrays so we never block-quantize a
+    # tensor the C++ loader reads as raw F32 (voices, CFG null tokens,
+    # style/expand constants, embedding tables).  Empty for other archs.
+    keep_f32_storage: set[str] = set()
+    if arch_name.startswith("supertonic"):
+        keep_f32_storage = build_supertonic_keep_f32(src)
+
     writer = gguf.GGUFWriter(args.dst, arch_name or "chatterbox-s3gen")
 
     # Copy all metadata (KV fields) verbatim.  Skip the ones the writer
@@ -296,7 +391,8 @@ def main() -> int:
         src_bytes += data.nbytes
 
         in_filter = name_filter is None or name_filter in t.name
-        if (in_filter and t.tensor_type in _QUANTIZABLE_SRC_DTYPES
+        if (in_filter and t.name not in keep_f32_storage
+                      and t.tensor_type in _QUANTIZABLE_SRC_DTYPES
                       and t.tensor_type != qtype
                       and should_quantize(t.name, shape, qtype)):
             # Reshape to natural (shape).  GGUF raw data is contiguous in
@@ -343,6 +439,10 @@ def main() -> int:
     print(f"arch: {arch_name!r}")
     print(f"quantized: {quantized_count} tensors to {args.dtype.upper()}")
     print(f"kept:      {kept_count} tensors as source dtype")
+    if keep_f32_storage:
+        print(f"           ({len(keep_f32_storage)} of them via the Supertonic "
+              f"raw-read roster: voices / CFG null tokens / style+expand "
+              f"constants / embeddings)")
     print(f"size:      {src_bytes / 1e6:.1f} MB  →  {dst_bytes / 1e6:.1f} MB  "
           f"({dst_bytes / src_bytes * 100:.1f}%)")
     return 0

--- a/tts-cpp/scripts/requantize-gguf.py
+++ b/tts-cpp/scripts/requantize-gguf.py
@@ -300,7 +300,23 @@ def should_quantize(name: str, shape: tuple[int, ...], qtype: gguf.GGMLQuantizat
     # path stays a no-op and the caller logs the kept-as-source-dtype
     # tensors via stats.kept.
     if len(shape) == 3:
-        return shape[-1] % block == 0
+        # Genuine K-aligned conv kernels (K a multiple of the block).  Rare
+        # in this stack (HiFT K in {3,7,11,16} never qualifies).
+        if shape[-1] % block == 0:
+            return True
+        # Pointwise (1x1) conv: stored 3-D as ggml ne=[K=1, IC, OC] (numpy
+        # (OC, IC, 1)).  Algebraically it's a 2-D matmul [IC, OC]; the K=1
+        # axis is trivial.  Squeeze the singleton and gate on the real
+        # reduction dim (IC).  When quantized we store it squeezed-2D and the
+        # C++ loader re-expands it to [1, IC, OC] at load (driven by the
+        # `supertonic.pwconv_squeezed` roster this script emits).  This is
+        # where the bulk of a Supertonic GGUF lives (ConvNeXt pwconv1/pwconv2
+        # in the vocoder + vector_estimator), so unlocking it is what takes a
+        # Q8_0 GGUF from ~96% of F32 down to ~32%.
+        squeezed = tuple(d for d in shape if d != 1)
+        if len(squeezed) == 2 and squeezed[-1] % block == 0:
+            return True
+        return False
 
     return False
 
@@ -380,6 +396,10 @@ def main() -> int:
     kept_count = 0
     src_bytes = 0
     dst_bytes = 0
+    # Storage names of pointwise (K=1) convs we squeezed 3-D [1,IC,OC] -> 2-D
+    # [IC,OC] before quantizing.  The C++ loader re-expands these to 3-D at
+    # load so the conv/matmul call sites see the original shape.
+    pwconv_squeezed_names: list[str] = []
 
     for t in src.tensors:
         # GGUFReader returns shape in numpy-style reversed order.
@@ -398,9 +418,23 @@ def main() -> int:
             # Reshape to natural (shape).  GGUF raw data is contiguous in
             # the original order, but reversed() above gives element-shape
             # which is what `quantize()` expects.
-            arr = data.astype(np.float32).reshape(shape)
+            #
+            # Pointwise (1x1) conv: squeeze the singleton K dim so `quantize`
+            # sees a 2-D [.., IC] matrix it can block-quantize along IC.  The
+            # squeezed-2D bytes are layout-identical to the 3-D [1,IC,OC]
+            # tensor, so the loader re-expands by name (no permutation).
+            quant_shape = shape
+            q_block = gguf.GGML_QUANT_SIZES[qtype][0]
+            squeezed_pwconv = (
+                len(shape) == 3 and (shape[-1] % q_block != 0) and (1 in shape)
+            )
+            if squeezed_pwconv:
+                quant_shape = tuple(d for d in shape if d != 1)
+            arr = data.astype(np.float32).reshape(quant_shape)
             qdata = gguf.quants.quantize(arr, qtype)
             writer.add_tensor(t.name, qdata, raw_shape=qdata.shape, raw_dtype=qtype)
+            if squeezed_pwconv:
+                pwconv_squeezed_names.append(t.name)
             quantized_count += 1
             dst_bytes += qdata.nbytes
         else:
@@ -431,6 +465,12 @@ def main() -> int:
             kept_count += 1
             dst_bytes += data.nbytes
 
+    # Emit the pointwise-conv re-expansion roster so the C++ loader restores
+    # the original 3-D [1,IC,OC] shape for these squeezed-2-D quantized
+    # tensors.  Only present when we actually squeezed something.
+    if pwconv_squeezed_names:
+        writer.add_array("supertonic.pwconv_squeezed", pwconv_squeezed_names)
+
     writer.write_header_to_file()
     writer.write_kv_data_to_file()
     writer.write_tensors_to_file()
@@ -438,6 +478,9 @@ def main() -> int:
 
     print(f"arch: {arch_name!r}")
     print(f"quantized: {quantized_count} tensors to {args.dtype.upper()}")
+    if pwconv_squeezed_names:
+        print(f"           ({len(pwconv_squeezed_names)} of them pointwise K=1 convs "
+              f"squeezed 3D->2D; loader re-expands via supertonic.pwconv_squeezed)")
     print(f"kept:      {kept_count} tensors as source dtype")
     if keep_f32_storage:
         print(f"           ({len(keep_f32_storage)} of them via the Supertonic "

--- a/tts-cpp/scripts/setup-supertonic2.sh
+++ b/tts-cpp/scripts/setup-supertonic2.sh
@@ -16,12 +16,13 @@ usage() {
 usage: bash scripts/setup-supertonic2.sh [options] [converter options]
 
 options:
-  --arch supertonic2|supertonic  Which upstream bundle to download.
+  --arch supertonic3|supertonic2|supertonic
+                                Which upstream bundle to download.
                                 default: supertonic2
   --repo-id REPO                Hugging Face repo override.
-                                default: Supertone/supertonic-2 or Supertone/supertonic
+                                default: Supertone/supertonic-3, -2, or -1 by arch
   --out PATH                    Output GGUF path.
-                                default: models/supertonic2.gguf or models/supertonic.gguf
+                                default: models/<arch>.gguf
   --python PATH                 Python interpreter. default: $PYTHON or python3
   -h, --help                    Show this help.
 
@@ -69,6 +70,10 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$ARCH" in
+    supertonic3)
+        REPO_ID="${REPO_ID:-Supertone/supertonic-3}"
+        OUT="${OUT:-$ROOT/models/supertonic3.gguf}"
+        ;;
     supertonic2)
         REPO_ID="${REPO_ID:-Supertone/supertonic-2}"
         OUT="${OUT:-$ROOT/models/supertonic2.gguf}"
@@ -78,7 +83,7 @@ case "$ARCH" in
         OUT="${OUT:-$ROOT/models/supertonic.gguf}"
         ;;
     *)
-        echo "error: --arch must be 'supertonic2' or 'supertonic'" >&2
+        echo "error: --arch must be 'supertonic3', 'supertonic2', or 'supertonic'" >&2
         exit 2
         ;;
 esac

--- a/tts-cpp/src/supertonic_gguf.cpp
+++ b/tts-cpp/src/supertonic_gguf.cpp
@@ -39,6 +39,12 @@ uint32_t get_u32(const gguf_context * ctx, const char * key) {
     return gguf_get_val_u32(ctx, require_key(ctx, key));
 }
 
+uint32_t get_u32(const gguf_context * ctx, const char * key, uint32_t fallback) {
+    int64_t id = gguf_find_key(ctx, key);
+    if (id < 0) return fallback;
+    return gguf_get_val_u32(ctx, id);
+}
+
 float get_f32(const gguf_context * ctx, const char * key) {
     return gguf_get_val_f32(ctx, require_key(ctx, key));
 }
@@ -1680,8 +1686,8 @@ static void bind_vocoder_weights(supertonic_model & model) {
     v.normalizer_scale = require_source_tensor(model, "vocoder:tts.ttl.normalizer.scale");
     v.latent_mean = require_source_tensor(model, "vocoder:tts.ae.latent_mean");
     v.latent_std = require_source_tensor(model, "vocoder:tts.ae.latent_std");
-    v.embed_w = require_source_tensor(model, "vocoder:onnx::Conv_1440");
-    v.embed_b = require_source_tensor(model, "vocoder:onnx::Conv_1441");
+    v.embed_w = require_source_tensor(model, "vocoder:node:/decoder/embed/net/Conv#1");
+    v.embed_b = require_source_tensor(model, "vocoder:node:/decoder/embed/net/Conv#2");
     for (int i = 0; i < 10; ++i) {
         const std::string p = "vocoder:tts.ae.decoder.convnext." + std::to_string(i);
         auto & c = v.convnext[(size_t) i];
@@ -1701,7 +1707,7 @@ static void bind_vocoder_weights(supertonic_model & model) {
     v.final_norm_running_var = require_source_tensor(model, "vocoder:tts.ae.decoder.final_norm.norm.running_var");
     v.head1_w = require_source_tensor(model, "vocoder:tts.ae.decoder.head.layer1.net.weight");
     v.head1_b = require_source_tensor(model, "vocoder:tts.ae.decoder.head.layer1.net.bias");
-    v.head_prelu = require_source_tensor(model, "vocoder:onnx::PRelu_1505");
+    v.head_prelu = require_source_tensor(model, "vocoder:node:/decoder/head/act/PRelu#1");
     v.head2_w = require_source_tensor(model, "vocoder:tts.ae.decoder.head.layer2.weight");
 }
 
@@ -1738,7 +1744,7 @@ bool load_supertonic_gguf(const std::string & path,
 
     try {
         std::string arch = get_string(gguf_ctx, "supertonic.arch");
-        if (arch != "supertonic2" && arch != "supertonic") {
+        if (arch != "supertonic3" && arch != "supertonic2" && arch != "supertonic") {
             throw std::runtime_error("unexpected supertonic.arch: " + arch);
         }
 
@@ -1752,10 +1758,14 @@ bool load_supertonic_gguf(const std::string & path,
         model.hparams.latent_channels = (int) get_u32(gguf_ctx, "supertonic.latent_channels");
         model.hparams.default_steps = (int) get_u32(gguf_ctx, "supertonic.default_steps");
         model.hparams.default_speed = get_f32(gguf_ctx, "supertonic.default_speed");
+        // v3 doubles the vector-estimator text cross-attention heads (4 -> 8),
+        // keeping head_dim=64.  Older bundles omit the key, so default to 4.
+        model.hparams.vector_text_attn_heads =
+            (int) get_u32(gguf_ctx, "supertonic.vector_text_attn_heads", 4);
         model.hparams.language_wrap_mode = get_string(gguf_ctx, "supertonic.language_wrap_mode");
         if (model.hparams.language_wrap_mode.empty()) {
             bool language_wrap = get_bool_u32(gguf_ctx, "supertonic.language_wrap", arch != "supertonic");
-            model.hparams.language_wrap_mode = language_wrap ? (arch == "supertonic2" ? "open_close" : "prefix") : "none";
+            model.hparams.language_wrap_mode = language_wrap ? (arch == "supertonic" ? "prefix" : "open_close") : "none";
         }
         model.hparams.default_voice = get_string(gguf_ctx, "supertonic.default_voice", "F1");
         model.languages = get_string_array(gguf_ctx, "supertonic.languages");
@@ -2415,6 +2425,39 @@ bool load_supertonic_gguf(const std::string & path,
                         ggml_backend_tensor_set(pre, raw.data(), 0, raw.size());
                     }
                     model.pretransposed_weights[orig] = pre;
+                }
+            }
+        }
+
+        // QVAC-19305 — register cross-family stable aliases.  The
+        // converter emits `supertonic.source_aliases[i]` (a canonical,
+        // version-independent key such as
+        // `vector_estimator:tts.ttl.vector_field.main_blocks.3.attn.W_query.linear.weight`)
+        // alongside `supertonic.source_alias_targets[i]` (the primary
+        // `<stage>:<onnx-name>` key the tensor already lives under, e.g.
+        // `vector_estimator:onnx::MatMul_3101`).  Registering both keys
+        // against the same tensor lets the runtime bind weights by their
+        // stable names regardless of how the ONNX exporter numbered them
+        // (Supertonic 2 vs 3).  Done here — after every weight,
+        // pre-transposed companion and materialised constant is already in
+        // `source_tensors` — so aliases are pure additive lookups and never
+        // perturb the load-time F6 / tanh_k / pretranspose passes above.
+        {
+            int64_t id_a = gguf_find_key(gguf_ctx, "supertonic.source_aliases");
+            int64_t id_t = gguf_find_key(gguf_ctx, "supertonic.source_alias_targets");
+            if (id_a >= 0 && id_t >= 0) {
+                std::vector<std::string> aliases = get_string_array(gguf_ctx, "supertonic.source_aliases");
+                std::vector<std::string> targets = get_string_array(gguf_ctx, "supertonic.source_alias_targets");
+                if (aliases.size() != targets.size()) {
+                    throw std::runtime_error("supertonic.source_aliases / source_alias_targets length mismatch");
+                }
+                for (size_t i = 0; i < aliases.size(); ++i) {
+                    auto it = model.source_tensors.find(targets[i]);
+                    if (it == model.source_tensors.end() || !it->second) continue;
+                    // Don't clobber a real primary entry with an alias.
+                    if (model.source_tensors.find(aliases[i]) == model.source_tensors.end()) {
+                        model.source_tensors[aliases[i]] = it->second;
+                    }
                 }
             }
         }

--- a/tts-cpp/src/supertonic_gguf.cpp
+++ b/tts-cpp/src/supertonic_gguf.cpp
@@ -143,8 +143,23 @@ ggml_type target_supertonic_storage_type(const std::string & name,
     // selector.  Everything else (biases, norms, scales, the unicode
     // indexer i32 lookup, etc.) is passed through unchanged so we don't
     // attempt a dequant on types that don't have a to_float trait.
+    //
+    // Q4_0 is recognised here purely so the switch below maps it to F32
+    // (there is no `supertonic_precision::Q4_0`, and the Q8_0 case gates
+    // on `src_type == GGML_TYPE_Q8_0`).  A Q4_0 GGUF therefore ALWAYS
+    // dequantizes to F32 at load on every backend.  This is deliberate:
+    // (a) the scalar-CPU continuation reads these weights via raw read_f32,
+    //     so a packed Q4_0 tensor would be byte-reinterpreted -> NaN, and
+    // (b) keeping Q4_0 live in the graph hit a SIGBUS in
+    //     `ggml_compute_forward_dup` on Metal (no Q4_0 CONT/DUP kernel for
+    //     the transposed matmul-weight path).  Block-quant only buys ~5 %
+    //     on this conv/raw-read-dominated model anyway, so dequant-at-load
+    //     is the correct trade: a Q4_0 GGUF loads + runs (slightly smaller
+    //     on disk, F32 in RAM) instead of crashing.
     const bool is_quantized_weight =
-        (src_type == GGML_TYPE_Q8_0) || (src_type == GGML_TYPE_F16);
+        (src_type == GGML_TYPE_Q8_0) ||
+        (src_type == GGML_TYPE_Q4_0) ||
+        (src_type == GGML_TYPE_F16);
     if (!is_quantized_weight) return src_type;
 
     switch (precision) {
@@ -187,7 +202,13 @@ bool needs_supertonic_tensor_conversion(enum ggml_type src_type,
 }
 
 bool should_expand_supertonic_tensor(enum ggml_type type) {
-    return type == GGML_TYPE_F16 || type == GGML_TYPE_Q8_0;
+    // Q4_0 is included so a Q4_0 GGUF loaded with `use_f16_weights` (or any
+    // path that expands a quantized source to f32) dequantizes via the
+    // `to_float` trait instead of falling through to the raw-memcpy branch
+    // that reinterprets packed Q4_0 blocks as floats.
+    return type == GGML_TYPE_F16 ||
+           type == GGML_TYPE_Q8_0 ||
+           type == GGML_TYPE_Q4_0;
 }
 
 std::vector<float> expand_supertonic_tensor_to_f32(const ggml_tensor * src) {
@@ -1956,6 +1977,25 @@ bool load_supertonic_gguf(const std::string & path,
             }
         }
 
+        // Pointwise (1x1) conv re-expansion roster.  The requantizer stores
+        // these ConvNeXt pwconv weights squeezed from 3-D ggml ne=[1,IC,OC]
+        // down to 2-D [IC,OC] so ggml can block-quantize along ne0=IC (a K=1
+        // leading axis is un-quantizable — the 32-element block needs
+        // ne0 % 32 == 0).  We re-expand them to the original [1,IC,OC] here
+        // so every conv/matmul call site sees the same shape it would for an
+        // F32/F16 GGUF (where these stay natively 3-D).  Absent on
+        // f32/f16/v1/v2 GGUFs -> empty set -> no-op.
+        std::unordered_set<std::string> pwconv_squeezed;
+        {
+            int64_t id_pw = gguf_find_key(gguf_ctx, "supertonic.pwconv_squeezed");
+            if (id_pw >= 0 && gguf_get_kv_type(gguf_ctx, id_pw) == GGUF_TYPE_ARRAY) {
+                const size_t n_pw = gguf_get_arr_n(gguf_ctx, id_pw);
+                for (size_t i = 0; i < n_pw; ++i) {
+                    pwconv_squeezed.insert(gguf_get_arr_str(gguf_ctx, id_pw, i));
+                }
+            }
+        }
+
         // Decide per-tensor destination type:
         //  1. F32 sources on the F16-weights hot-path roster +
         //     `use_f16_weights` on → materialise as F16 (Phase 2A).
@@ -2034,9 +2074,21 @@ bool load_supertonic_gguf(const std::string & path,
                     /*backend_is_cpu=*/ ggml_backend_is_cpu(model.backend));
             }
 
-            ggml_tensor * dst = (dst_type == src->type)
-                ? ggml_dup_tensor(model.ctx_w, src)
-                : ggml_new_tensor(model.ctx_w, dst_type, ggml_n_dims(src), src->ne);
+            ggml_tensor * dst;
+            if (pwconv_squeezed.count(name)) {
+                // Requantizer squeezed this pointwise conv 3-D [1,IC,OC] ->
+                // 2-D [IC,OC] so it could be block-quantized.  Re-expand to
+                // [1, IC, OC] (= [1, src->ne[0], src->ne[1]]); the dequantized
+                // upload below is byte-identical to the original 3-D tensor.
+                // dst_type is F32 here (pwconv names aren't matmul-weight
+                // names, so the storage selector always dequantizes them).
+                const int64_t ne3[3] = { 1, src->ne[0], src->ne[1] };
+                dst = ggml_new_tensor(model.ctx_w, dst_type, 3, ne3);
+            } else {
+                dst = (dst_type == src->type)
+                    ? ggml_dup_tensor(model.ctx_w, src)
+                    : ggml_new_tensor(model.ctx_w, dst_type, ggml_n_dims(src), src->ne);
+            }
             ggml_set_name(dst, name);
             model.tensors[name] = dst;
 

--- a/tts-cpp/src/supertonic_gguf.cpp
+++ b/tts-cpp/src/supertonic_gguf.cpp
@@ -2135,6 +2135,73 @@ bool load_supertonic_gguf(const std::string & path,
             }
         }
 
+        // QVAC-19305 — register cross-family stable aliases *before* any
+        // load-time pass that binds weights by their canonical names
+        // (`bind_vocoder_weights` below binds the vocoder embed/head conv
+        // weights this way, and the speech-prompted text-encoder reads its
+        // projections by canonical name at synth time).  The converter
+        // emits `supertonic.source_aliases[i]` (a canonical,
+        // version-independent key such as
+        // `vector_estimator:tts.ttl.vector_field.main_blocks.3.attn.W_query.linear.weight`
+        // or `vocoder:node:/decoder/embed/net/Conv#1`) alongside
+        // `supertonic.source_alias_targets[i]` (the primary
+        // `<stage>:<onnx-name>` key the tensor already lives under, e.g.
+        // `vector_estimator:onnx::MatMul_3101`).  Registering both keys
+        // against the same tensor lets the runtime bind weights by their
+        // stable names regardless of how the ONNX exporter numbered them
+        // (Supertonic 2 vs 3).  The pretranspose pass below dedupes by
+        // tensor pointer, so the extra `onnx::MatMul_` bridge keys never
+        // cause a weight to be pre-transposed (or re-allocated) twice.
+        {
+            int64_t id_a = gguf_find_key(gguf_ctx, "supertonic.source_aliases");
+            int64_t id_t = gguf_find_key(gguf_ctx, "supertonic.source_alias_targets");
+            if (id_a >= 0 && id_t >= 0) {
+                std::vector<std::string> aliases = get_string_array(gguf_ctx, "supertonic.source_aliases");
+                std::vector<std::string> targets = get_string_array(gguf_ctx, "supertonic.source_alias_targets");
+                if (aliases.size() != targets.size()) {
+                    throw std::runtime_error("supertonic.source_aliases / source_alias_targets length mismatch");
+                }
+                for (size_t i = 0; i < aliases.size(); ++i) {
+                    auto it = model.source_tensors.find(targets[i]);
+                    if (it == model.source_tensors.end() || !it->second) continue;
+                    // Don't clobber a real primary entry with an alias.
+                    if (model.source_tensors.find(aliases[i]) == model.source_tensors.end()) {
+                        model.source_tensors[aliases[i]] = it->second;
+                    }
+                }
+            }
+        }
+
+        // QVAC-19305 — backward compatibility for GGUFs produced by the
+        // pre-v3 converter, which ship *no* alias arrays.  The v3 runtime
+        // binds the vocoder embed/head conv weights and the speech-prompted
+        // text-encoder projections by stable canonical names; on an older
+        // GGUF those canonical keys are absent and only the legacy
+        // Supertonic-1/2 ONNX auto-ids exist.  Map each canonical name to
+        // its v2 primary so existing GGUFs keep loading without a
+        // re-conversion.  This is a no-op for v3 / freshly re-converted v2
+        // models, where the converter already registered the canonical key
+        // in the alias pass above (the `find(canonical)` guard skips them).
+        {
+            static const std::pair<const char *, const char *> kLegacyV2Aliases[] = {
+                { "vocoder:node:/decoder/embed/net/Conv#1",                                             "vocoder:onnx::Conv_1440" },
+                { "vocoder:node:/decoder/embed/net/Conv#2",                                             "vocoder:onnx::Conv_1441" },
+                { "vocoder:node:/decoder/head/act/PRelu#1",                                             "vocoder:onnx::PRelu_1505" },
+                { "text_encoder:tts.ttl.speech_prompted_text_encoder.attention1.W_query.linear.weight", "text_encoder:onnx::MatMul_3678" },
+                { "text_encoder:tts.ttl.speech_prompted_text_encoder.attention1.W_value.linear.weight", "text_encoder:onnx::MatMul_3680" },
+                { "text_encoder:tts.ttl.speech_prompted_text_encoder.attention1.out_fc.linear.weight",  "text_encoder:onnx::MatMul_3681" },
+                { "text_encoder:tts.ttl.speech_prompted_text_encoder.attention2.W_query.linear.weight", "text_encoder:onnx::MatMul_3682" },
+                { "text_encoder:tts.ttl.speech_prompted_text_encoder.attention2.W_value.linear.weight", "text_encoder:onnx::MatMul_3684" },
+                { "text_encoder:tts.ttl.speech_prompted_text_encoder.attention2.out_fc.linear.weight",  "text_encoder:onnx::MatMul_3685" },
+            };
+            for (const auto & [canonical, legacy] : kLegacyV2Aliases) {
+                if (model.source_tensors.find(canonical) != model.source_tensors.end()) continue;
+                auto it = model.source_tensors.find(legacy);
+                if (it == model.source_tensors.end() || !it->second) continue;
+                model.source_tensors[canonical] = it->second;
+            }
+        }
+
         for (const std::string & voice_name : get_string_array(gguf_ctx, "supertonic.voice_names")) {
             supertonic_voice_style voice;
             voice.name = voice_name;
@@ -2325,9 +2392,17 @@ bool load_supertonic_gguf(const std::string & path,
         if (!disable_pretranspose && model.backend &&
             !ggml_backend_is_cpu(model.backend)) {
             std::vector<std::pair<std::string, ggml_tensor *>> to_pretranspose;
+            // Dedupe by tensor pointer: cross-family bridge aliases register
+            // a second `:onnx::MatMul_` key (the v2 logical id) against the
+            // same physical tensor as its v3 primary, so a plain name scan
+            // would otherwise pre-transpose — and re-allocate — the weight
+            // twice.  The runtime looks pretransposed copies up by pointer
+            // (`pretransposed_weights`), so one entry per tensor suffices.
+            std::unordered_set<const ggml_tensor *> seen_pre;
             for (const auto & [src_name, t] : model.source_tensors) {
                 if (!t) continue;
                 if (src_name.find(":onnx::MatMul_") == std::string::npos) continue;
+                if (!seen_pre.insert(t).second) continue;
                 if (ggml_n_dims(t) != 2) continue;
                 // Pretranspose f32 weights (default precision) AND q8_0 / f16
                 // weights (asymmetric load modes).  For q8_0 / f16 we
@@ -2425,39 +2500,6 @@ bool load_supertonic_gguf(const std::string & path,
                         ggml_backend_tensor_set(pre, raw.data(), 0, raw.size());
                     }
                     model.pretransposed_weights[orig] = pre;
-                }
-            }
-        }
-
-        // QVAC-19305 — register cross-family stable aliases.  The
-        // converter emits `supertonic.source_aliases[i]` (a canonical,
-        // version-independent key such as
-        // `vector_estimator:tts.ttl.vector_field.main_blocks.3.attn.W_query.linear.weight`)
-        // alongside `supertonic.source_alias_targets[i]` (the primary
-        // `<stage>:<onnx-name>` key the tensor already lives under, e.g.
-        // `vector_estimator:onnx::MatMul_3101`).  Registering both keys
-        // against the same tensor lets the runtime bind weights by their
-        // stable names regardless of how the ONNX exporter numbered them
-        // (Supertonic 2 vs 3).  Done here — after every weight,
-        // pre-transposed companion and materialised constant is already in
-        // `source_tensors` — so aliases are pure additive lookups and never
-        // perturb the load-time F6 / tanh_k / pretranspose passes above.
-        {
-            int64_t id_a = gguf_find_key(gguf_ctx, "supertonic.source_aliases");
-            int64_t id_t = gguf_find_key(gguf_ctx, "supertonic.source_alias_targets");
-            if (id_a >= 0 && id_t >= 0) {
-                std::vector<std::string> aliases = get_string_array(gguf_ctx, "supertonic.source_aliases");
-                std::vector<std::string> targets = get_string_array(gguf_ctx, "supertonic.source_alias_targets");
-                if (aliases.size() != targets.size()) {
-                    throw std::runtime_error("supertonic.source_aliases / source_alias_targets length mismatch");
-                }
-                for (size_t i = 0; i < aliases.size(); ++i) {
-                    auto it = model.source_tensors.find(targets[i]);
-                    if (it == model.source_tensors.end() || !it->second) continue;
-                    // Don't clobber a real primary entry with an alias.
-                    if (model.source_tensors.find(aliases[i]) == model.source_tensors.end()) {
-                        model.source_tensors[aliases[i]] = it->second;
-                    }
                 }
             }
         }

--- a/tts-cpp/src/supertonic_gguf.cpp
+++ b/tts-cpp/src/supertonic_gguf.cpp
@@ -61,6 +61,32 @@ std::string get_string(const gguf_context * ctx, const char * key, const std::st
     return gguf_get_val_str(ctx, id);
 }
 
+// Reads a GGUF array of any integer width into ints.  Returns empty when the
+// key is absent or not an integer array, so callers can fall back cleanly.
+std::vector<int> get_int_array(const gguf_context * ctx, const char * key) {
+    int64_t id = gguf_find_key(ctx, key);
+    if (id < 0 || gguf_get_kv_type(ctx, id) != GGUF_TYPE_ARRAY) return {};
+    const size_t n = gguf_get_arr_n(ctx, id);
+    const enum gguf_type t = gguf_get_arr_type(ctx, id);
+    const void * data = gguf_get_arr_data(ctx, id);
+    std::vector<int> out;
+    out.reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+        switch (t) {
+            case GGUF_TYPE_INT8:   out.push_back((int) ((const int8_t *) data)[i]); break;
+            case GGUF_TYPE_UINT8:  out.push_back((int) ((const uint8_t *) data)[i]); break;
+            case GGUF_TYPE_INT16:  out.push_back((int) ((const int16_t *) data)[i]); break;
+            case GGUF_TYPE_UINT16: out.push_back((int) ((const uint16_t *) data)[i]); break;
+            case GGUF_TYPE_INT32:  out.push_back((int) ((const int32_t *) data)[i]); break;
+            case GGUF_TYPE_UINT32: out.push_back((int) ((const uint32_t *) data)[i]); break;
+            case GGUF_TYPE_INT64:  out.push_back((int) ((const int64_t *) data)[i]); break;
+            case GGUF_TYPE_UINT64: out.push_back((int) ((const uint64_t *) data)[i]); break;
+            default: return {};
+        }
+    }
+    return out;
+}
+
 std::vector<std::string> get_string_array(const gguf_context * ctx, const char * key) {
     int64_t id = require_key(ctx, key);
     size_t n = gguf_get_arr_n(ctx, id);
@@ -1372,7 +1398,16 @@ supertonic_op_dispatch_scope::supertonic_op_dispatch_scope(const supertonic_mode
       prev_use_f16_attn(g_supertonic_use_f16_attn),
       prev_use_native_leaky_relu(g_supertonic_use_native_leaky_relu),
       prev_kv_attn_type(g_supertonic_kv_attn_type) {
-    g_supertonic_use_cpu_custom_ops    = model.backend_is_cpu;
+    // The CPU custom-op fast paths (CBLAS sgemm, fused depthwise/layernorm,
+    // tail update) read their weight args as raw F32, so they cannot consume
+    // block-quantized (Q4_0/Q8_0) weights — doing so reinterprets the packed
+    // blocks as floats (SIGBUS / garbage).  `SUPERTONIC_DISABLE_CPU_CUSTOM_OPS`
+    // forces the pure-GGML decomposition instead, whose mul_mat/get_rows
+    // dequantize in-op.  Lets a CPU-only box validate quantized GGUFs (which
+    // otherwise only run on GPU/Metal backends).
+    static const bool disable_cpu_custom_ops =
+        std::getenv("SUPERTONIC_DISABLE_CPU_CUSTOM_OPS") != nullptr;
+    g_supertonic_use_cpu_custom_ops    = model.backend_is_cpu && !disable_cpu_custom_ops;
     g_supertonic_use_f16_attn          = model.use_f16_attn;
     g_supertonic_use_native_leaky_relu = model.use_native_leaky_relu;
     g_supertonic_kv_attn_type          = model.kv_attn_type;
@@ -1762,6 +1797,17 @@ bool load_supertonic_gguf(const std::string & path,
         // keeping head_dim=64.  Older bundles omit the key, so default to 4.
         model.hparams.vector_text_attn_heads =
             (int) get_u32(gguf_ctx, "supertonic.vector_text_attn_heads", 4);
+        // Per-block text-encoder ConvNeXt dilations (v3 dilates this stack).
+        // Absent on v1/v2 (and pre-key) bundles -> empty -> dilation 1 per block.
+        model.hparams.text_convnext_dilations =
+            get_int_array(gguf_ctx, "supertonic.text_convnext_dilations");
+        // Classifier-free-guidance scales (v3).  Default (1, 0) = no guidance.
+        {
+            int64_t kc = gguf_find_key(gguf_ctx, "supertonic.cfg_cond_scale");
+            int64_t ku = gguf_find_key(gguf_ctx, "supertonic.cfg_uncond_scale");
+            if (kc >= 0) model.hparams.cfg_cond_scale = gguf_get_val_f32(gguf_ctx, kc);
+            if (ku >= 0) model.hparams.cfg_uncond_scale = gguf_get_val_f32(gguf_ctx, ku);
+        }
         model.hparams.language_wrap_mode = get_string(gguf_ctx, "supertonic.language_wrap_mode");
         if (model.hparams.language_wrap_mode.empty()) {
             bool language_wrap = get_bool_u32(gguf_ctx, "supertonic.language_wrap", arch != "supertonic");

--- a/tts-cpp/src/supertonic_internal.h
+++ b/tts-cpp/src/supertonic_internal.h
@@ -55,8 +55,27 @@ struct supertonic_hparams {
     // head_dim stays 64).  Read from GGUF `supertonic.vector_text_attn_heads`,
     // defaulting to 4 for bundles converted before the key existed.
     int vector_text_attn_heads = 4;
+    // Per-block dwconv dilations of the text-encoder ConvNeXt stack.  v1/v2 use
+    // dilation 1 everywhere; Supertonic 3 dilates it (e.g. {1,1,2,2,4,4}).  Read
+    // from GGUF `supertonic.text_convnext_dilations`.  Empty => every block uses
+    // dilation 1 (the v1/v2 behaviour, and the fallback for older bundles whose
+    // converter predates the key).
+    std::vector<int> text_convnext_dilations;
+    // Classifier-free-guidance scales for the vector estimator.  v3 bakes a
+    // batch-2 (conditional + unconditional) field whose velocity is
+    // `cfg_cond_scale*v_cond - cfg_uncond_scale*v_uncond` (e.g. 4*cond-3*uncond).
+    // v1/v2 (and pre-key bundles) default to (1, 0) = single conditional pass.
+    float cfg_cond_scale = 1.0f;
+    float cfg_uncond_scale = 0.0f;
+    bool cfg_enabled() const { return cfg_uncond_scale != 0.0f; }
     std::string language_wrap_mode = "open_close";
     std::string default_voice = "F1";
+
+    // Dilation for text-encoder ConvNeXt block `block`, defaulting to 1 when the
+    // bundle does not pin a per-block schedule (v1/v2, or pre-key conversions).
+    int text_convnext_dilation(size_t block) const {
+        return block < text_convnext_dilations.size() ? text_convnext_dilations[block] : 1;
+    }
 };
 
 struct supertonic_voice_style {
@@ -946,7 +965,15 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
                                        std::string * error = nullptr,
                                        bool include_scalar_trace = true,
                                        bool include_ggml_trace = true,
-                                       std::vector<float> * next_latent_tc_out = nullptr);
+                                       std::vector<float> * next_latent_tc_out = nullptr,
+                                       // CFG (Supertonic 3): when both provided, the
+                                       // production ggml path uses these channel-major
+                                       // [50,256] style layouts instead of deriving the
+                                       // conditional ones from `style_ttl` /
+                                       // `/Expand_output_0`.  Lets the caller run an
+                                       // unconditional pass with the learned null tokens.
+                                       const std::vector<float> * style_v_raw_override = nullptr,
+                                       const std::vector<float> * kctx_raw_override = nullptr);
 
 // Process-wide alive registry: each loaded supertonic_model registers
 // its generation_id with this set on success and unregisters at the

--- a/tts-cpp/src/supertonic_internal.h
+++ b/tts-cpp/src/supertonic_internal.h
@@ -50,6 +50,11 @@ struct supertonic_hparams {
     int latent_channels = 144;
     int default_steps = 5;
     float default_speed = 1.05f;
+    // Vector-estimator text cross-attention head count.  The only internal
+    // topology dim that differs across families (v1/v2: 4 heads, v3: 8 heads;
+    // head_dim stays 64).  Read from GGUF `supertonic.vector_text_attn_heads`,
+    // defaulting to 4 for bundles converted before the key existed.
+    int vector_text_attn_heads = 4;
     std::string language_wrap_mode = "open_close";
     std::string default_voice = "F1";
 };
@@ -619,10 +624,15 @@ ggml_tensor * try_source_tensor(const supertonic_model & model, const std::strin
 // conv1d kernel `[K=1, IC, OC]` directly and skip the cont(transpose(w)).
 ggml_tensor * try_pretransposed_weight(const supertonic_model & model, const ggml_tensor * w);
 
+// `supported_languages`, when non-null and non-empty, is the authoritative set
+// of accepted language codes (the model's `supertonic.languages` GGUF array).
+// When null/empty the function falls back to the legacy built-in 5-language
+// allowlist so direct callers/tests without a model keep working.
 std::string supertonic_preprocess_text(const std::string & text,
                                        const std::string & language,
                                        const std::string & language_wrap_mode,
-                                       bool is_continuation = false);
+                                       bool is_continuation = false,
+                                       const std::vector<std::string> * supported_languages = nullptr);
 bool supertonic_text_to_ids(const supertonic_model & model,
                             const std::string & text,
                             const std::string & language,

--- a/tts-cpp/src/supertonic_preprocess.cpp
+++ b/tts-cpp/src/supertonic_preprocess.cpp
@@ -162,9 +162,19 @@ bool has_terminal_punct(const std::string & s) {
     }
 }
 
+// Legacy built-in allowlist (Supertonic v1/v2).  Used only as the fallback
+// when the caller does not supply the model's `supertonic.languages` array.
 bool is_supported_language(const std::string & language) {
     return language == "en" || language == "ko" || language == "es" ||
            language == "pt" || language == "fr";
+}
+
+bool is_language_allowed(const std::string & language,
+                         const std::vector<std::string> * supported) {
+    if (supported == nullptr || supported->empty()) {
+        return is_supported_language(language);
+    }
+    return std::find(supported->begin(), supported->end(), language) != supported->end();
 }
 
 } // namespace
@@ -172,8 +182,9 @@ bool is_supported_language(const std::string & language) {
 std::string supertonic_preprocess_text(const std::string & text,
                                        const std::string & language,
                                        const std::string & language_wrap_mode,
-                                       bool is_continuation) {
-    if (!is_supported_language(language)) {
+                                       bool is_continuation,
+                                       const std::vector<std::string> * supported_languages) {
+    if (!is_language_allowed(language, supported_languages)) {
         throw std::runtime_error("invalid Supertonic language: " + language);
     }
 
@@ -234,7 +245,8 @@ bool supertonic_text_to_ids(const supertonic_model & model,
                             bool is_continuation) {
     try {
         std::string normalized = supertonic_preprocess_text(
-            text, language, model.hparams.language_wrap_mode, is_continuation);
+            text, language, model.hparams.language_wrap_mode, is_continuation,
+            &model.languages);
         std::vector<uint32_t> cps = utf8_to_cps(normalized);
         ids.clear();
         ids.reserve(cps.size());

--- a/tts-cpp/src/supertonic_text_encoder.cpp
+++ b/tts-cpp/src/supertonic_text_encoder.cpp
@@ -698,11 +698,11 @@ void speech_prompted_attention(const supertonic_model & m, int idx,
     const float scale = 1.0f / 16.0f;
     const int attn_num = idx + 1;
     const std::string p = "text_encoder:tts.ttl.speech_prompted_text_encoder.attention" + std::to_string(attn_num);
-    f32_tensor q_w = read_f32(m, "text_encoder:" + std::string(idx == 0 ? "onnx::MatMul_3678" : "onnx::MatMul_3682"));
+    f32_tensor q_w = read_f32(m, p + ".W_query.linear.weight");
     f32_tensor q_b = read_f32(m, p + ".W_query.linear.bias");
-    f32_tensor kv_w = read_f32(m, "text_encoder:" + std::string(idx == 0 ? "onnx::MatMul_3680" : "onnx::MatMul_3684"));
+    f32_tensor kv_w = read_f32(m, p + ".W_value.linear.weight");
     f32_tensor kv_b = read_f32(m, p + ".W_value.linear.bias");
-    f32_tensor out_w = read_f32(m, "text_encoder:" + std::string(idx == 0 ? "onnx::MatMul_3681" : "onnx::MatMul_3685"));
+    f32_tensor out_w = read_f32(m, p + ".out_fc.linear.weight");
     f32_tensor out_b = read_f32(m, p + ".out_fc.linear.bias");
     f32_tensor tanh_k = read_f32(m, "text_encoder:/speech_prompted_text_encoder/attention" + std::to_string(attn_num) + "/tanh/Tanh_output_0");
 
@@ -1055,9 +1055,9 @@ void speech_prompted_attention_ggml(const supertonic_model & m, int idx,
     if (idx < 0 || idx >= 2) throw std::runtime_error("invalid speech attention idx");
     const int attn_num = idx + 1;
     const std::string p = "text_encoder:tts.ttl.speech_prompted_text_encoder.attention" + std::to_string(attn_num);
-    const std::string q_w = "text_encoder:" + std::string(idx == 0 ? "onnx::MatMul_3678" : "onnx::MatMul_3682");
-    const std::string v_w = "text_encoder:" + std::string(idx == 0 ? "onnx::MatMul_3680" : "onnx::MatMul_3684");
-    const std::string o_w = "text_encoder:" + std::string(idx == 0 ? "onnx::MatMul_3681" : "onnx::MatMul_3685");
+    const std::string q_w = p + ".W_query.linear.weight";
+    const std::string v_w = p + ".W_value.linear.weight";
+    const std::string o_w = p + ".out_fc.linear.weight";
     const std::string tanh_k_src = "text_encoder:/speech_prompted_text_encoder/attention" + std::to_string(attn_num) + "/tanh/Tanh_output_0";
 
     // QVAC-18605 round 12 #6 — merged-cache fast path on non-CPU

--- a/tts-cpp/src/supertonic_text_encoder.cpp
+++ b/tts-cpp/src/supertonic_text_encoder.cpp
@@ -194,7 +194,8 @@ ggml_tensor * edge_clamp_pad_1d(ggml_context * ctx, ggml_tensor * x, int pad_lef
 ggml_tensor * depthwise_same_ggml(ggml_context * ctx,
                                   ggml_tensor * x,
                                   ggml_tensor * w,
-                                  ggml_tensor * b) {
+                                  ggml_tensor * b,
+                                  int dilation) {
     const int K = (int)w->ne[0];
     static const bool disable_fused =
         std::getenv("SUPERTONIC_DISABLE_FUSED_DEPTHWISE") != nullptr;
@@ -204,13 +205,15 @@ ggml_tensor * depthwise_same_ggml(ggml_context * ctx,
         x->ne[2] == 1 && x->ne[3] == 1 && w->ne[1] == 1 && w->ne[3] == 1 &&
         w->ne[2] == x->ne[1] && b->ne[0] == x->ne[1] &&
         ggml_is_contiguous(x) && ggml_is_contiguous(w) && ggml_is_contiguous(b)) {
-        return ggml_supertonic_depthwise_1d(ctx, x, w, b, 1);
+        return ggml_supertonic_depthwise_1d(ctx, x, w, b, dilation);
     }
-    const int pad_left = (K - 1) / 2;
-    const int pad_right = (K - 1) - pad_left;
+    // "Same" padding under dilation: effective kernel span is (K-1)*dilation+1.
+    const int total_pad = (K - 1) * dilation;
+    const int pad_left = total_pad / 2;
+    const int pad_right = total_pad - pad_left;
     ggml_tensor * padded = edge_clamp_pad_1d(ctx, x, pad_left, pad_right);
     ggml_tensor * new_b = ggml_reshape_4d(ctx, padded, padded->ne[0], 1, padded->ne[1], padded->ne[2]);
-    ggml_tensor * im2col = ggml_im2col(ctx, w, new_b, 1, 0, 0, 0, 1, 0, false, GGML_TYPE_F32);
+    ggml_tensor * im2col = ggml_im2col(ctx, w, new_b, 1, 0, 0, 0, dilation, 0, false, GGML_TYPE_F32);
     ggml_tensor * y = ggml_mul_mat(ctx, im2col, w);
     y = ggml_reshape_3d(ctx, y, y->ne[0], y->ne[2], 1);
     return ggml_add(ctx, y, repeat_like(ctx, b, y));
@@ -258,11 +261,13 @@ ggml_tensor * conv1d_k1_channel_time_ggml(ggml_context * ctx,
 ggml_tensor * text_convnext_ggml(ggml_context * ctx,
                                 const supertonic_model & model,
                                 const std::string & p,
-                                ggml_tensor * x) {
+                                ggml_tensor * x,
+                                int dilation) {
     ggml_tensor * residual = x;
     ggml_tensor * y = depthwise_same_ggml(ctx, x,
         require_source_tensor(model, p + ".dwconv.weight"),
-        require_source_tensor(model, p + ".dwconv.bias"));
+        require_source_tensor(model, p + ".dwconv.bias"),
+        dilation);
     y = layer_norm_ggml(ctx, y,
         require_source_tensor(model, p + ".norm.norm.weight"),
         require_source_tensor(model, p + ".norm.norm.bias"));
@@ -367,7 +372,7 @@ void layer_norm_channel(std::vector<float> & x, int L, int C,
 }
 
 void convnext_block(const supertonic_model & m, const std::string & p,
-                    std::vector<float> & x, int L, int C) {
+                    std::vector<float> & x, int L, int C, int dilation) {
     f32_tensor dw_w = read_f32(m, p + ".dwconv.weight");
     f32_tensor dw_b = read_f32(m, p + ".dwconv.bias");
     f32_tensor ln_g = read_f32(m, p + ".norm.norm.weight");
@@ -379,7 +384,7 @@ void convnext_block(const supertonic_model & m, const std::string & p,
     f32_tensor gamma = read_f32(m, p + ".gamma");
     std::vector<float> residual = x;
     std::vector<float> y, z;
-    depthwise_conv1d_same(x, L, C, dw_w, dw_b, (int) dw_w.ne[0], 1, y);
+    depthwise_conv1d_same(x, L, C, dw_w, dw_b, (int) dw_w.ne[0], dilation, y);
     layer_norm_channel(y, L, C, ln_g, ln_b);
     linear1x1(y, L, C, pw1_w, &pw1_b, (int) pw1_w.ne[2], z);
     for (float & v : z) v = gelu(v);
@@ -1222,7 +1227,8 @@ bool supertonic_text_encoder_forward_cpu(const supertonic_model & model,
         }
 
         for (int i = 0; i < 6; ++i) {
-            convnext_block(model, "text_encoder:tts.ttl.text_encoder.convnext.convnext." + std::to_string(i), x, L, C);
+            convnext_block(model, "text_encoder:tts.ttl.text_encoder.convnext.convnext." + std::to_string(i),
+                           x, L, C, model.hparams.text_convnext_dilation((size_t) i));
         }
         std::vector<float> convnext_out = x;
 
@@ -1355,7 +1361,8 @@ bool supertonic_text_encoder_forward_ggml(const supertonic_model & model,
             ggml_tensor * y_t = in_t;
             for (int i = 0; i < 6; ++i) {
                 y_t = text_convnext_ggml(convnext_cache.ctx, model,
-                    "text_encoder:tts.ttl.text_encoder.convnext.convnext." + std::to_string(i), y_t);
+                    "text_encoder:tts.ttl.text_encoder.convnext.convnext." + std::to_string(i), y_t,
+                    model.hparams.text_convnext_dilation((size_t) i));
             }
             ggml_set_name(y_t, "text_encoder_convnext5");
             ggml_set_output(y_t);
@@ -1475,7 +1482,8 @@ bool supertonic_text_encoder_trace_ggml(const supertonic_model & model,
         push_trace(scalar_trace, "text_encoder_embed", L, C, x);
         std::vector<float> cur = x;
         for (int i = 0; i < 6; ++i) {
-            convnext_block(model, "text_encoder:tts.ttl.text_encoder.convnext.convnext." + std::to_string(i), cur, L, C);
+            convnext_block(model, "text_encoder:tts.ttl.text_encoder.convnext.convnext." + std::to_string(i),
+                           cur, L, C, model.hparams.text_convnext_dilation((size_t) i));
             push_trace(scalar_trace, "text_encoder_convnext" + std::to_string(i), L, C, cur);
         }
         std::vector<float> q0, k0, v0;
@@ -1502,7 +1510,8 @@ bool supertonic_text_encoder_trace_ggml(const supertonic_model & model,
         ggml_set_name(in, "text_encoder_embed"); ggml_set_input(in);
         ggml_tensor * y = in;
         for (int i = 0; i < 6; ++i) {
-            y = text_convnext_ggml(ctx, model, "text_encoder:tts.ttl.text_encoder.convnext.convnext." + std::to_string(i), y);
+            y = text_convnext_ggml(ctx, model, "text_encoder:tts.ttl.text_encoder.convnext.convnext." + std::to_string(i), y,
+                                   model.hparams.text_convnext_dilation((size_t) i));
             const std::string name = "text_encoder_convnext" + std::to_string(i);
             ggml_set_name(y, name.c_str()); ggml_set_output(y);
             ggml_build_forward_expand(gf, y);

--- a/tts-cpp/src/supertonic_vector_estimator.cpp
+++ b/tts-cpp/src/supertonic_vector_estimator.cpp
@@ -1651,7 +1651,7 @@ void build_group_graph_cache(vector_group_graph_cache & cache,
     // the GGUF didn't ship a `vector_rope_theta` (cache.apply_rope
     // stays false; call sites then keep the legacy host
     // apply_rope call).
-    const int H = 4;
+    const int H = model.hparams.vector_text_attn_heads;  // v1/v2=4, v3=8
     const int D = 64;
     const int half = D / 2;
     cache.apply_rope = (int) model.vector_rope_theta.size() == half;
@@ -2692,7 +2692,12 @@ void apply_rope(const float * theta, std::vector<float> & x, int L, int H, int D
 void rope_attn(const supertonic_model & m, int group, std::vector<float> & x, int L,
                const float * text_emb, int LT, std::vector<float> & out) {
     static const int qids[4]={3101,3146,3191,3236}, kids[4]={3102,3147,3192,3237}, vids[4]={3103,3148,3193,3238}, oids[4]={3110,3155,3200,3245};
-    int C=512, A=256, H=4, D=64;
+    // Text cross-attention head count differs across families (v1/v2: 4 heads,
+    // v3: 8 heads); head_dim stays 64 so the internal width A = H*64 grows
+    // 256 -> 512 in v3.  Bound from GGUF metadata.
+    const int D=64;
+    const int H=m.hparams.vector_text_attn_heads;
+    int C=512, A=H*D;
     std::string base="vector_estimator:tts.ttl.vector_field.main_blocks."+std::to_string(group*6+3)+".attn.";
     std::vector<float> q,k,v;
     dense_matmul_time(x,L,C,read_f32(m,"vector_estimator:onnx::MatMul_"+std::to_string(qids[group])),read_f32(m,base+"W_query.linear.bias"),A,q);
@@ -2806,6 +2811,10 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
         const int L = latent_len;
         const int Cin = model.hparams.latent_channels;
         const int C = 512;
+        // Text cross-attention head count: v1/v2=4, v3=8.  head_dim stays 64,
+        // so the internal attention width A = H_text*64 (256 -> 512 in v3).
+        const int H_text = model.hparams.vector_text_attn_heads;
+        const int A_text = H_text * 64;
 #define PUSH_GGML_TRACE(...) do { if (include_ggml_trace) ggml_trace.push_back(supertonic_trace_tensor __VA_ARGS__); } while (0)
         profile_vector_step_begin(current_step);
         std::vector<float> in((size_t) L * Cin);
@@ -2850,7 +2859,7 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
             convnext(model, "vector_estimator:tts.ttl.vector_field.main_blocks.2.convnext.0", block, L, C, 1);
             push_trace(scalar_trace, "ve_block2_convnext0", L, C, block);
 
-            const int A = 256;
+            const int A = A_text;
             std::string base = "vector_estimator:tts.ttl.vector_field.main_blocks.3.attn.";
             std::vector<float> q, k, v;
             dense_matmul_time(block, L, C, read_f32(model, "vector_estimator:onnx::MatMul_3101"),
@@ -2870,13 +2879,13 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
             push_trace(scalar_trace, "ve_attn0_v", text_len, A, v);
             // F1: theta lives in model.vector_rope_theta (populated at load).
             const float * theta_t = model.vector_rope_theta.data();
-            apply_rope(theta_t, q, L, 4, 64);
-            apply_rope(theta_t, k, text_len, 4, 64);
+            apply_rope(theta_t, q, L, H_text, 64);
+            apply_rope(theta_t, k, text_len, H_text, 64);
             push_trace(scalar_trace, "ve_attn0_q_rope", L, A, q);
             push_trace(scalar_trace, "ve_attn0_k_rope", text_len, A, k);
 
             std::vector<float> attn_ctx((size_t)L*A, 0.0f), scores(text_len), probs(text_len);
-            const int H = 4, D = 64;
+            const int H = H_text, D = 64;
             const float scale = 1.0f / 16.0f;
             for (int h = 0; h < H; ++h) for (int qi = 0; qi < L; ++qi) {
                 float mx = -INFINITY;
@@ -2988,7 +2997,7 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
         push_trace(scalar_trace, "ve_group1_block8_convnext0", L, C, residual);
 
         {
-            const int A1 = 256;
+            const int A1 = A_text;
             std::string base1 = "vector_estimator:tts.ttl.vector_field.main_blocks.9.attn.";
             std::vector<float> q1, k1, v1;
             dense_matmul_time(residual, L, C, read_f32(model, "vector_estimator:onnx::MatMul_3146"),
@@ -3002,23 +3011,23 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
             push_trace(scalar_trace, "ve_g1_attn_v", text_len, A1, v1);
             // F1: theta lives in model.vector_rope_theta (populated at load).
             const float * theta1 = model.vector_rope_theta.data();
-            apply_rope(theta1, q1, L, 4, 64);
-            apply_rope(theta1, k1, text_len, 4, 64);
+            apply_rope(theta1, q1, L, H_text, 64);
+            apply_rope(theta1, k1, text_len, H_text, 64);
             push_trace(scalar_trace, "ve_g1_attn_q_rope", L, A1, q1);
             push_trace(scalar_trace, "ve_g1_attn_k_rope", text_len, A1, k1);
             std::vector<float> ctx1((size_t)L*A1, 0.0f), scores1(text_len), probs1(text_len);
-            for (int h = 0; h < 4; ++h) for (int qi = 0; qi < L; ++qi) {
+            for (int h = 0; h < H_text; ++h) for (int qi = 0; qi < L; ++qi) {
                 float mx = -INFINITY;
                 for (int kj = 0; kj < text_len; ++kj) {
                     float s = 0.0f;
-                    for (int d = 0; d < 64; ++d) s += q1[((size_t)qi*4+h)*64+d] * k1[((size_t)kj*4+h)*64+d] * (1.0f/16.0f);
+                    for (int d = 0; d < 64; ++d) s += q1[((size_t)qi*H_text+h)*64+d] * k1[((size_t)kj*H_text+h)*64+d] * (1.0f/16.0f);
                     scores1[kj] = s; mx = std::max(mx, s);
                 }
                 float den = 0.0f;
                 for (int kj = 0; kj < text_len; ++kj) { probs1[kj] = std::exp(scores1[kj]-mx); den += probs1[kj]; }
                 for (int d = 0; d < 64; ++d) {
                     float sum = 0.0f;
-                    for (int kj = 0; kj < text_len; ++kj) sum += (probs1[kj]/den) * v1[((size_t)kj*4+h)*64+d];
+                    for (int kj = 0; kj < text_len; ++kj) sum += (probs1[kj]/den) * v1[((size_t)kj*H_text+h)*64+d];
                     ctx1[(size_t)qi*A1 + h*64 + d] = sum;
                 }
             }
@@ -3100,7 +3109,7 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
         push_trace(scalar_trace, "ve_group2_block14_convnext0", L, C, residual);
 
         {
-            const int A2 = 256;
+            const int A2 = A_text;
             std::string base2 = "vector_estimator:tts.ttl.vector_field.main_blocks.15.attn.";
             std::vector<float> q2, k2, v2;
             dense_matmul_time(residual, L, C, read_f32(model, "vector_estimator:onnx::MatMul_3191"),
@@ -3114,23 +3123,23 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
             push_trace(scalar_trace, "ve_g2_attn_v", text_len, A2, v2);
             // F1: theta lives in model.vector_rope_theta (populated at load).
             const float * theta2 = model.vector_rope_theta.data();
-            apply_rope(theta2, q2, L, 4, 64);
-            apply_rope(theta2, k2, text_len, 4, 64);
+            apply_rope(theta2, q2, L, H_text, 64);
+            apply_rope(theta2, k2, text_len, H_text, 64);
             push_trace(scalar_trace, "ve_g2_attn_q_rope", L, A2, q2);
             push_trace(scalar_trace, "ve_g2_attn_k_rope", text_len, A2, k2);
             std::vector<float> ctx2((size_t)L*A2, 0.0f), scores2(text_len), probs2(text_len);
-            for (int h = 0; h < 4; ++h) for (int qi = 0; qi < L; ++qi) {
+            for (int h = 0; h < H_text; ++h) for (int qi = 0; qi < L; ++qi) {
                 float mx = -INFINITY;
                 for (int kj = 0; kj < text_len; ++kj) {
                     float s = 0.0f;
-                    for (int d = 0; d < 64; ++d) s += q2[((size_t)qi*4+h)*64+d] * k2[((size_t)kj*4+h)*64+d] * (1.0f/16.0f);
+                    for (int d = 0; d < 64; ++d) s += q2[((size_t)qi*H_text+h)*64+d] * k2[((size_t)kj*H_text+h)*64+d] * (1.0f/16.0f);
                     scores2[kj] = s; mx = std::max(mx, s);
                 }
                 float den = 0.0f;
                 for (int kj = 0; kj < text_len; ++kj) { probs2[kj] = std::exp(scores2[kj]-mx); den += probs2[kj]; }
                 for (int d = 0; d < 64; ++d) {
                     float sum = 0.0f;
-                    for (int kj = 0; kj < text_len; ++kj) sum += (probs2[kj]/den) * v2[((size_t)kj*4+h)*64+d];
+                    for (int kj = 0; kj < text_len; ++kj) sum += (probs2[kj]/den) * v2[((size_t)kj*H_text+h)*64+d];
                     ctx2[(size_t)qi*A2 + h*64 + d] = sum;
                 }
             }
@@ -3212,7 +3221,7 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
         push_trace(scalar_trace, "ve_group3_block20_convnext0", L, C, residual);
 
         {
-            const int A3 = 256;
+            const int A3 = A_text;
             std::string base3 = "vector_estimator:tts.ttl.vector_field.main_blocks.21.attn.";
             std::vector<float> q3, k3, v3;
             dense_matmul_time(residual, L, C, read_f32(model, "vector_estimator:onnx::MatMul_3236"),
@@ -3226,23 +3235,23 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
             push_trace(scalar_trace, "ve_g3_attn_v", text_len, A3, v3);
             // F1: theta lives in model.vector_rope_theta (populated at load).
             const float * theta3 = model.vector_rope_theta.data();
-            apply_rope(theta3, q3, L, 4, 64);
-            apply_rope(theta3, k3, text_len, 4, 64);
+            apply_rope(theta3, q3, L, H_text, 64);
+            apply_rope(theta3, k3, text_len, H_text, 64);
             push_trace(scalar_trace, "ve_g3_attn_q_rope", L, A3, q3);
             push_trace(scalar_trace, "ve_g3_attn_k_rope", text_len, A3, k3);
             std::vector<float> ctx3((size_t)L*A3, 0.0f), scores3(text_len), probs3(text_len);
-            for (int h = 0; h < 4; ++h) for (int qi = 0; qi < L; ++qi) {
+            for (int h = 0; h < H_text; ++h) for (int qi = 0; qi < L; ++qi) {
                 float mx = -INFINITY;
                 for (int kj = 0; kj < text_len; ++kj) {
                     float s = 0.0f;
-                    for (int d = 0; d < 64; ++d) s += q3[((size_t)qi*4+h)*64+d] * k3[((size_t)kj*4+h)*64+d] * (1.0f/16.0f);
+                    for (int d = 0; d < 64; ++d) s += q3[((size_t)qi*H_text+h)*64+d] * k3[((size_t)kj*H_text+h)*64+d] * (1.0f/16.0f);
                     scores3[kj] = s; mx = std::max(mx, s);
                 }
                 float den = 0.0f;
                 for (int kj = 0; kj < text_len; ++kj) { probs3[kj] = std::exp(scores3[kj]-mx); den += probs3[kj]; }
                 for (int d = 0; d < 64; ++d) {
                     float sum = 0.0f;
-                    for (int kj = 0; kj < text_len; ++kj) sum += (probs3[kj]/den) * v3[((size_t)kj*4+h)*64+d];
+                    for (int kj = 0; kj < text_len; ++kj) sum += (probs3[kj]/den) * v3[((size_t)kj*H_text+h)*64+d];
                     ctx3[(size_t)qi*A3 + h*64 + d] = sum;
                 }
             }
@@ -3561,7 +3570,7 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
             // call site below can drop the host `apply_rope`
             // round-trips.  Falls through to the legacy host
             // rotation path when the GGUF didn't ship theta.
-            const int FRONT_H = 4;
+            const int FRONT_H = H_text;
             const int FRONT_D = 64;
             const int FRONT_HALF = FRONT_D / 2;
             front_cache.apply_rope =
@@ -3744,7 +3753,7 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
             // Mirrors the g1/g2/g3 dispatch at lines 2926-2933.
             attn_out_ggml = run_text_attention_cache_gpu(att0_cache, model,
                 q_rope_gpu_attn0, k_rope_gpu_attn0, v_gpu_attn0,
-                L, text_len, 4, 64,
+                L, text_len, H_text, 64,
                 "vector_estimator:onnx::MatMul_3110",
                 "vector_estimator:tts.ttl.vector_field.main_blocks.3.attn.out_fc.linear.bias",
                 current_step, "attn0_flash",
@@ -3801,13 +3810,13 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
                     k_out = tensor_to_time_channel(ggml_graph_get_tensor(gf, "ve_attn0_k"));
                 }
                 const float * theta = model.vector_rope_theta.data();
-                apply_rope(theta, q_out, L, 4, 64);
-                apply_rope(theta, k_out, text_len, 4, 64);
+                apply_rope(theta, q_out, L, H_text, 64);
+                apply_rope(theta, k_out, text_len, H_text, 64);
                 q_rotated = std::move(q_out);
                 k_rotated = std::move(k_out);
             }
             attn_out_ggml = run_text_attention_cache(att0_cache, model, q_rotated, k_rotated, v_out,
-                L, text_len, 4, 64,
+                L, text_len, H_text, 64,
                 "vector_estimator:onnx::MatMul_3110",
                 "vector_estimator:tts.ttl.vector_field.main_blocks.3.attn.out_fc.linear.bias",
                 current_step, "attn0_flash",
@@ -3919,7 +3928,7 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
         if (g1_group.q_rope_gpu && g1_group.k_rope_gpu && g1_group.v_gpu) {
             g1_attn_out = run_text_attention_cache_gpu(g1_attn_cache, model,
                 g1_group.q_rope_gpu, g1_group.k_rope_gpu, g1_group.v_gpu,
-                L, text_len, 4, 64,
+                L, text_len, H_text, 64,
                 "vector_estimator:onnx::MatMul_3155",
                 "vector_estimator:tts.ttl.vector_field.main_blocks.9.attn.out_fc.linear.bias",
                 current_step, "g1_attn_flash",
@@ -3931,11 +3940,11 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
             std::vector<float> g1q_rotated = g1q_out;
             std::vector<float> g1k_rotated = g1k_out;
             const float * theta_g1 = model.vector_rope_theta.data();
-            apply_rope(theta_g1, g1q_rotated, L, 4, 64);
-            apply_rope(theta_g1, g1k_rotated, text_len, 4, 64);
+            apply_rope(theta_g1, g1q_rotated, L, H_text, 64);
+            apply_rope(theta_g1, g1k_rotated, text_len, H_text, 64);
             g1_attn_out = run_text_attention_cache(g1_attn_cache, model,
                 g1q_rotated, g1k_rotated, g1v_out,
-                L, text_len, 4, 64,
+                L, text_len, H_text, 64,
                 "vector_estimator:onnx::MatMul_3155",
                 "vector_estimator:tts.ttl.vector_field.main_blocks.9.attn.out_fc.linear.bias",
                 current_step, "g1_attn_flash",
@@ -4029,7 +4038,7 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
         if (g2_group.q_rope_gpu && g2_group.k_rope_gpu && g2_group.v_gpu) {
             g2_attn_out = run_text_attention_cache_gpu(g2_attn_cache, model,
                 g2_group.q_rope_gpu, g2_group.k_rope_gpu, g2_group.v_gpu,
-                L, text_len, 4, 64,
+                L, text_len, H_text, 64,
                 "vector_estimator:onnx::MatMul_3200",
                 "vector_estimator:tts.ttl.vector_field.main_blocks.15.attn.out_fc.linear.bias",
                 current_step, "g2_attn_flash",
@@ -4041,11 +4050,11 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
             std::vector<float> g2q_rotated = g2q_out;
             std::vector<float> g2k_rotated = g2k_out;
             const float * theta_g2 = model.vector_rope_theta.data();
-            apply_rope(theta_g2, g2q_rotated, L, 4, 64);
-            apply_rope(theta_g2, g2k_rotated, text_len, 4, 64);
+            apply_rope(theta_g2, g2q_rotated, L, H_text, 64);
+            apply_rope(theta_g2, g2k_rotated, text_len, H_text, 64);
             g2_attn_out = run_text_attention_cache(g2_attn_cache, model,
                 g2q_rotated, g2k_rotated, g2v_out,
-                L, text_len, 4, 64,
+                L, text_len, H_text, 64,
                 "vector_estimator:onnx::MatMul_3200",
                 "vector_estimator:tts.ttl.vector_field.main_blocks.15.attn.out_fc.linear.bias",
                 current_step, "g2_attn_flash",
@@ -4133,7 +4142,7 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
         if (g3_group.q_rope_gpu && g3_group.k_rope_gpu && g3_group.v_gpu) {
             g3_attn_out = run_text_attention_cache_gpu(g3_attn_cache, model,
                 g3_group.q_rope_gpu, g3_group.k_rope_gpu, g3_group.v_gpu,
-                L, text_len, 4, 64,
+                L, text_len, H_text, 64,
                 "vector_estimator:onnx::MatMul_3245",
                 "vector_estimator:tts.ttl.vector_field.main_blocks.21.attn.out_fc.linear.bias",
                 current_step, "g3_attn_flash",
@@ -4145,11 +4154,11 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
             std::vector<float> g3q_rotated = g3q_out;
             std::vector<float> g3k_rotated = g3k_out;
             const float * theta_g3 = model.vector_rope_theta.data();
-            apply_rope(theta_g3, g3q_rotated, L, 4, 64);
-            apply_rope(theta_g3, g3k_rotated, text_len, 4, 64);
+            apply_rope(theta_g3, g3q_rotated, L, H_text, 64);
+            apply_rope(theta_g3, g3k_rotated, text_len, H_text, 64);
             g3_attn_out = run_text_attention_cache(g3_attn_cache, model,
                 g3q_rotated, g3k_rotated, g3v_out,
-                L, text_len, 4, 64,
+                L, text_len, H_text, 64,
                 "vector_estimator:onnx::MatMul_3245",
                 "vector_estimator:tts.ttl.vector_field.main_blocks.21.attn.out_fc.linear.bias",
                 current_step, "g3_attn_flash",
@@ -4459,8 +4468,8 @@ ggml_tensor * append_supertonic_vector_step_subgraph(
     // Shape constants that aren't dependent on L / text_len.  Mirror the
     // values from supertonic_vector_step_one_graph_ggml.
     const int C = 512;
-    const int H = 4;        // text-attention heads
-    const int D = 64;       // text-attention head_dim
+    const int H = model.hparams.vector_text_attn_heads;  // text-attn heads: v1/v2=4, v3=8
+    const int D = 64;       // text-attention head_dim (constant; width A = H*D)
     const int SH = 2;       // style-attention heads
     const int SD = 128;     // style-attention head_dim
     const int kv_style = 50; // fixed by /Expand_output_0
@@ -4696,9 +4705,9 @@ bool supertonic_vector_step_one_graph_ggml(const supertonic_model & model,
         const int Cin = model.hparams.latent_channels;  // typically 16
         const int C = 512;
         const int text_C = 256;
-        const int H = 4;        // text-attention heads
+        const int H = model.hparams.vector_text_attn_heads;  // v1/v2=4, v3=8
         const int D = 64;       // text-attention head_dim
-        const int A = H * D;    // 256 = attention width
+        const int A = H * D;    // attention width: 256 (v1/v2) or 512 (v3)
         const int SH = 2;       // style-attention heads
         const int SD = 128;     // style-attention head_dim
         const int kv_style = 50; // style attention kv length (fixed by /Expand_output_0)

--- a/tts-cpp/src/supertonic_vector_estimator.cpp
+++ b/tts-cpp/src/supertonic_vector_estimator.cpp
@@ -2720,14 +2720,19 @@ void rope_attn(const supertonic_model & m, int group, std::vector<float> & x, in
     dense_matmul_time(attn_out,L,A,read_f32(m,"vector_estimator:onnx::MatMul_"+std::to_string(oids[group])),read_f32(m,base+"out_fc.linear.bias"),C,out);
 }
 
-void style_attn(const supertonic_model & m, int group, std::vector<float> & x, int L, const float * style_ttl, std::vector<float> & out) {
+// `style_ttl` is the style value input (V).  `style_key` overrides the key
+// input (K); when null the conditional path's `/Expand_output_0` constant is
+// used.  CFG's unconditional pass passes the learned `style_key_special_token`.
+void style_attn(const supertonic_model & m, int group, std::vector<float> & x, int L,
+                const float * style_ttl, const float * style_key, std::vector<float> & out) {
     static const int qids[4]={3116,3161,3206,3251}, kids[4]={3117,3162,3207,3252}, vids[4]={3118,3163,3208,3253}, oids[4]={3119,3164,3209,3254};
     int C=512,A=256,H=2,D=128,LC=50;
     std::string base="vector_estimator:tts.ttl.vector_field.main_blocks."+std::to_string(group*6+5)+".attention.";
     std::vector<float> q,k,v,ctx((size_t)LC*256),kctx((size_t)LC*256);
     for(int t=0;t<LC;++t) for(int c=0;c<256;++c) ctx[(size_t)t*256+c]=style_ttl[(size_t)t*256+c];
-    auto kconst=read_f32(m,"vector_estimator:/Expand_output_0");
-    for(int t=0;t<LC;++t) for(int c=0;c<256;++c) kctx[(size_t)t*256+c]=kconst.data[(size_t)t*256+c];
+    f32_tensor kconst;
+    if(!style_key) kconst=read_f32(m,"vector_estimator:/Expand_output_0");
+    for(int t=0;t<LC;++t) for(int c=0;c<256;++c) kctx[(size_t)t*256+c]= style_key ? style_key[(size_t)t*256+c] : kconst.data[(size_t)t*256+c];
     dense_matmul_time(x,L,C,read_f32(m,"vector_estimator:onnx::MatMul_"+std::to_string(qids[group])),read_f32(m,base+"W_query.linear.bias"),A,q);
     dense_matmul_time(kctx,LC,256,read_f32(m,"vector_estimator:onnx::MatMul_"+std::to_string(kids[group])),read_f32(m,base+"W_key.linear.bias"),A,k);
     for(float &vv:k) vv=std::tanh(vv);
@@ -2753,36 +2758,70 @@ bool supertonic_vector_step_cpu(const supertonic_model & model, const float * no
         int L=latent_len,Cin=144,C=512;
         std::vector<float> in((size_t)L*Cin);
         for(int t=0;t<L;++t) for(int c=0;c<Cin;++c) in[(size_t)t*Cin+c]=noisy_latent[(size_t)c*L+t];
-        std::vector<float> x;
-        conv1x1(in,L,Cin,read_f32(model,"vector_estimator:tts.ttl.vector_field.proj_in.net.weight"),nullptr,C,x);
-        for(int t=0;t<L;++t) for(int c=0;c<C;++c) x[(size_t)t*C+c]*=latent_mask[t];
         // F9: cached time-embedding (5 distinct keys per default schedule).
         auto te_arr = cached_time_embedding(model, current_step, total_steps);
         std::vector<float> te(te_arr.begin(), te_arr.end());
         static const int time_ids[4]={3095,3140,3185,3230};
-        for(int group=0;group<4;++group){
-            int ob=group*6;
-            int dils[4]={1,2,4,8};
-            for(int j=0;j<4;++j) convnext(model,"vector_estimator:tts.ttl.vector_field.main_blocks."+std::to_string(ob)+".convnext."+std::to_string(j),x,L,C,dils[j]);
-            std::vector<float> tb;
-            dense_matmul_vec(te,read_f32(model,"vector_estimator:onnx::MatMul_"+std::to_string(time_ids[group])),
-                             read_f32(model,"vector_estimator:tts.ttl.vector_field.main_blocks."+std::to_string(ob+1)+".linear.linear.bias"),64,C,tb);
-            for(int t=0;t<L;++t) for(int c=0;c<C;++c) x[(size_t)t*C+c]+=tb[c];
-            convnext(model,"vector_estimator:tts.ttl.vector_field.main_blocks."+std::to_string(ob+2)+".convnext.0",x,L,C,1);
-            std::vector<float> a; rope_attn(model,group,x,L,text_emb,text_len,a);
-            for(size_t i=0;i<x.size();++i) x[i]+=a[i];
-            layer_norm(x,L,C,read_f32(model,"vector_estimator:tts.ttl.vector_field.main_blocks."+std::to_string(ob+3)+".norm.norm.weight"),read_f32(model,"vector_estimator:tts.ttl.vector_field.main_blocks."+std::to_string(ob+3)+".norm.norm.bias"));
-            convnext(model,"vector_estimator:tts.ttl.vector_field.main_blocks."+std::to_string(ob+4)+".convnext.0",x,L,C,1);
-            style_attn(model,group,x,L,style_ttl,a);
-            for(size_t i=0;i<x.size();++i) x[i]+=a[i];
-            layer_norm(x,L,C,read_f32(model,"vector_estimator:tts.ttl.vector_field.main_blocks."+std::to_string(ob+5)+".norm.norm.weight"),read_f32(model,"vector_estimator:tts.ttl.vector_field.main_blocks."+std::to_string(ob+5)+".norm.norm.bias"));
-        }
-        for(int j=0;j<4;++j) convnext(model,"vector_estimator:tts.ttl.vector_field.last_convnext.convnext."+std::to_string(j),x,L,C,1);
-        std::vector<float> v;
-        conv1x1(x,L,C,read_f32(model,"vector_estimator:tts.ttl.vector_field.proj_out.net.weight"),nullptr,Cin,v);
+
+        // One conditional/unconditional pass of the vector field.  `text_cond`
+        // is [256, text_len] channel-major; `style_v` is the [50,256] style
+        // value input; `style_k` overrides the style key input (null => the
+        // conditional `/Expand_output_0` constant).  Returns the per-step
+        // velocity-applied latent (channel-major [Cin, L]).
+        auto run_field = [&](const float * text_cond, const float * style_v,
+                             const float * style_k, std::vector<float> & out_cl) {
+            std::vector<float> xf;
+            conv1x1(in,L,Cin,read_f32(model,"vector_estimator:tts.ttl.vector_field.proj_in.net.weight"),nullptr,C,xf);
+            for(int t=0;t<L;++t) for(int c=0;c<C;++c) xf[(size_t)t*C+c]*=latent_mask[t];
+            for(int group=0;group<4;++group){
+                int ob=group*6;
+                int dils[4]={1,2,4,8};
+                for(int j=0;j<4;++j) convnext(model,"vector_estimator:tts.ttl.vector_field.main_blocks."+std::to_string(ob)+".convnext."+std::to_string(j),xf,L,C,dils[j]);
+                std::vector<float> tb;
+                dense_matmul_vec(te,read_f32(model,"vector_estimator:onnx::MatMul_"+std::to_string(time_ids[group])),
+                                 read_f32(model,"vector_estimator:tts.ttl.vector_field.main_blocks."+std::to_string(ob+1)+".linear.linear.bias"),64,C,tb);
+                for(int t=0;t<L;++t) for(int c=0;c<C;++c) xf[(size_t)t*C+c]+=tb[c];
+                convnext(model,"vector_estimator:tts.ttl.vector_field.main_blocks."+std::to_string(ob+2)+".convnext.0",xf,L,C,1);
+                std::vector<float> a; rope_attn(model,group,xf,L,text_cond,text_len,a);
+                for(size_t i=0;i<xf.size();++i) xf[i]+=a[i];
+                layer_norm(xf,L,C,read_f32(model,"vector_estimator:tts.ttl.vector_field.main_blocks."+std::to_string(ob+3)+".norm.norm.weight"),read_f32(model,"vector_estimator:tts.ttl.vector_field.main_blocks."+std::to_string(ob+3)+".norm.norm.bias"));
+                convnext(model,"vector_estimator:tts.ttl.vector_field.main_blocks."+std::to_string(ob+4)+".convnext.0",xf,L,C,1);
+                style_attn(model,group,xf,L,style_v,style_k,a);
+                for(size_t i=0;i<xf.size();++i) xf[i]+=a[i];
+                layer_norm(xf,L,C,read_f32(model,"vector_estimator:tts.ttl.vector_field.main_blocks."+std::to_string(ob+5)+".norm.norm.weight"),read_f32(model,"vector_estimator:tts.ttl.vector_field.main_blocks."+std::to_string(ob+5)+".norm.norm.bias"));
+            }
+            for(int j=0;j<4;++j) convnext(model,"vector_estimator:tts.ttl.vector_field.last_convnext.convnext."+std::to_string(j),xf,L,C,1);
+            conv1x1(xf,L,C,read_f32(model,"vector_estimator:tts.ttl.vector_field.proj_out.net.weight"),nullptr,Cin,out_cl);
+        };
+
+        // Conditional pass (style value = style_ttl, key = /Expand_output_0).
+        std::vector<float> v_cond;
+        run_field(text_emb, style_ttl, nullptr, v_cond);
+
         next_latent_out.assign((size_t)Cin*L,0.0f);
+        if (!model.hparams.cfg_enabled()) {
+            for(int c=0;c<Cin;++c) for(int t=0;t<L;++t) {
+                float vel=v_cond[(size_t)t*Cin+c]*latent_mask[t];
+                next_latent_out[(size_t)c*L+t]=noisy_latent[(size_t)c*L+t]+vel/(float)total_steps;
+            }
+            if(error) error->clear(); return true;
+        }
+
+        // Unconditional pass — learned null tokens replace text / style K+V.
+        // velocity = cond_scale*v_cond - uncond_scale*v_uncond; the noise term
+        // cancels under `next = noise + velocity/N`, so we combine `next`s with
+        // the same coefficients (cond_scale - uncond_scale == 1).
+        f32_tensor tst = read_f32(model, "vector_estimator:tts.ttl.uncond_masker.text_special_token");  // [256]
+        f32_tensor skt = read_f32(model, "vector_estimator:tts.ttl.uncond_masker.style_key_special_token");   // [50,256]
+        f32_tensor svt = read_f32(model, "vector_estimator:tts.ttl.uncond_masker.style_value_special_token"); // [50,256]
+        std::vector<float> uncond_text((size_t)256*text_len);
+        for(int c=0;c<256;++c) for(int t=0;t<text_len;++t) uncond_text[(size_t)c*text_len+t]=tst.data[c];
+        std::vector<float> v_uncond;
+        run_field(uncond_text.data(), svt.data.data(), skt.data.data(), v_uncond);
+
+        const float cs = model.hparams.cfg_cond_scale, us = model.hparams.cfg_uncond_scale;
         for(int c=0;c<Cin;++c) for(int t=0;t<L;++t) {
-            float vel=v[(size_t)t*Cin+c]*latent_mask[t];
+            float vel=(cs*v_cond[(size_t)t*Cin+c] - us*v_uncond[(size_t)t*Cin+c])*latent_mask[t];
             next_latent_out[(size_t)c*L+t]=noisy_latent[(size_t)c*L+t]+vel/(float)total_steps;
         }
         if(error) error->clear(); return true;
@@ -2803,7 +2842,9 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
                                        std::string * error,
                                        bool include_scalar_trace,
                                        bool include_ggml_trace,
-                                       std::vector<float> * next_latent_tc_out) {
+                                       std::vector<float> * next_latent_tc_out,
+                                       const std::vector<float> * style_v_raw_override,
+                                       const std::vector<float> * kctx_raw_override) {
     supertonic_op_dispatch_scope dispatch(model);
     try {
         scalar_trace.clear();
@@ -3834,7 +3875,15 @@ bool supertonic_vector_trace_proj_ggml(const supertonic_model & model,
 
         const std::vector<float> * style_v_raw = nullptr;
         const std::vector<float> * kctx_raw = nullptr;
-        cached_style_layouts(model, style_ttl, style_v_raw, kctx_raw);
+        if (style_v_raw_override && kctx_raw_override) {
+            // CFG unconditional pass: caller supplies the learned null-token
+            // style V/K layouts (already in the channel-major [50,256] form
+            // that `cached_style_layouts` produces for the conditional path).
+            style_v_raw = style_v_raw_override;
+            kctx_raw    = kctx_raw_override;
+        } else {
+            cached_style_layouts(model, style_ttl, style_v_raw, kctx_raw);
+        }
         thread_local vector_res_style_qkv_cache style0_res_qkv_cache;
         SUPERTONIC_REGISTER_TL_CACHE(style0_res_qkv_cache, free_res_style_qkv_cache);
         vector_res_style_qkv_result style0_res_qkv = run_res_style_qkv_cache(
@@ -4423,6 +4472,11 @@ struct vector_step_one_graph_cache {
     ggml_tensor * style_v_raw_in = nullptr; // [50, 256] (style_ttl repacked)
     ggml_tensor * style_kctx_in = nullptr;  // [50, 256] (model's /Expand_output_0)
     ggml_tensor * noise_in = nullptr;       // (L, Cin) (same data as x_in but indep slot for tail)
+    // CFG unconditional-pass inputs (v3 only; null when cfg disabled): learned
+    // null tokens replacing text / style-K / style-V.
+    ggml_tensor * text_in_u = nullptr;       // [text_len, 256]
+    ggml_tensor * style_v_raw_in_u = nullptr; // [50, 256]
+    ggml_tensor * style_kctx_in_u = nullptr;  // [50, 256]
 
     // Per-build (rope) inputs
     ggml_tensor * pos_q = nullptr;          // int32 [L]
@@ -4452,6 +4506,7 @@ void free_vector_step_one_graph_cache(vector_step_one_graph_cache & cache) {
     cache.total_steps = 0;
     cache.x_in = cache.mask_in = cache.t_emb_in = cache.text_in = nullptr;
     cache.style_v_raw_in = cache.style_kctx_in = cache.noise_in = nullptr;
+    cache.text_in_u = cache.style_v_raw_in_u = cache.style_kctx_in_u = nullptr;
     cache.pos_q = cache.pos_k = cache.freq_factors_q = cache.freq_factors_k = nullptr;
     cache.next_latent_out = nullptr;
 }
@@ -4700,6 +4755,9 @@ bool supertonic_vector_step_one_graph_ggml(const supertonic_model & model,
     // The outer entry point sets `supertonic_op_dispatch_scope`; this
     // function is only called on non-CPU backends, so the thread-local
     // `supertonic_use_cpu_custom_ops()` reads false inside the helpers.
+    if (std::getenv("SUPERTONIC_VE_DEBUG"))
+        std::fprintf(stderr, "[ve-cfg] one_graph entry: cfg_enabled=%d cond=%g uncond=%g\n",
+            (int)model.hparams.cfg_enabled(), model.hparams.cfg_cond_scale, model.hparams.cfg_uncond_scale);
     try {
         const int L = latent_len;
         const int Cin = model.hparams.latent_channels;  // typically 16
@@ -4731,7 +4789,8 @@ bool supertonic_vector_step_one_graph_ggml(const supertonic_model & model,
             // sub-graphs each used 128-512 nodes; the full per-step graph is
             // roughly the sum (4 groups x ~700 ops/group + tail + front).
             // Round up generously.
-            constexpr int MAX_NODES = 8192;
+            // CFG (v3) builds the field twice (cond + uncond) in one graph.
+            const int MAX_NODES = model.hparams.cfg_enabled() ? 16384 : 8192;
             const size_t buf_size = ggml_tensor_overhead() * MAX_NODES +
                                      ggml_graph_overhead_custom(MAX_NODES, false);
             cache.buf.assign(buf_size, 0);
@@ -4754,6 +4813,14 @@ bool supertonic_vector_step_one_graph_ggml(const supertonic_model & model,
             ggml_set_name(cache.style_kctx_in, "step_style_kctx"); ggml_set_input(cache.style_kctx_in);
             cache.noise_in = ggml_new_tensor_2d(cache.ctx, GGML_TYPE_F32, L, Cin);
             ggml_set_name(cache.noise_in, "step_noise_in"); ggml_set_input(cache.noise_in);
+            if (model.hparams.cfg_enabled()) {
+                cache.text_in_u = ggml_new_tensor_2d(cache.ctx, GGML_TYPE_F32, text_len, text_C);
+                ggml_set_name(cache.text_in_u, "step_text_in_u"); ggml_set_input(cache.text_in_u);
+                cache.style_v_raw_in_u = ggml_new_tensor_2d(cache.ctx, GGML_TYPE_F32, kv_style, text_C);
+                ggml_set_name(cache.style_v_raw_in_u, "step_style_v_u"); ggml_set_input(cache.style_v_raw_in_u);
+                cache.style_kctx_in_u = ggml_new_tensor_2d(cache.ctx, GGML_TYPE_F32, kv_style, text_C);
+                ggml_set_name(cache.style_kctx_in_u, "step_style_kctx_u"); ggml_set_input(cache.style_kctx_in_u);
+            }
 
             // --- RoPE inputs ---
             cache.pos_q = ggml_new_tensor_1d(cache.ctx, GGML_TYPE_I32, L);
@@ -4783,6 +4850,21 @@ bool supertonic_vector_step_one_graph_ggml(const supertonic_model & model,
 
             ggml_tensor * next = append_supertonic_vector_step_subgraph(
                 gctx, gf, model, inputs, L, text_len, total_steps);
+
+            if (model.hparams.cfg_enabled()) {
+                // Unconditional pass shares everything but the conditioning.
+                vector_step_inputs inputs_u = inputs;
+                inputs_u.text_in        = cache.text_in_u;
+                inputs_u.style_v_raw_in = cache.style_v_raw_in_u;
+                inputs_u.style_kctx_in  = cache.style_kctx_in_u;
+                ggml_tensor * next_u = append_supertonic_vector_step_subgraph(
+                    gctx, gf, model, inputs_u, L, text_len, total_steps);
+                // next = cond_scale*next_cond - uncond_scale*next_uncond
+                // (noise term cancels because cond_scale - uncond_scale == 1).
+                next = ggml_sub(gctx,
+                    ggml_scale(gctx, next,   model.hparams.cfg_cond_scale),
+                    ggml_scale(gctx, next_u, model.hparams.cfg_uncond_scale));
+            }
 
             ggml_set_name(next, "step_next_latent");
             ggml_set_output(next);
@@ -4823,6 +4905,25 @@ bool supertonic_vector_step_one_graph_ggml(const supertonic_model & model,
         cached_style_layouts(model, style_ttl, style_v_raw_ptr, kctx_raw_ptr);
         ggml_backend_tensor_set(cache.style_v_raw_in, style_v_raw_ptr->data(), 0, style_v_raw_ptr->size() * sizeof(float));
         ggml_backend_tensor_set(cache.style_kctx_in, kctx_raw_ptr->data(), 0, kctx_raw_ptr->size() * sizeof(float));
+
+        if (model.hparams.cfg_enabled()) {
+            // Learned null tokens, repacked to the same channel-major layouts
+            // (text [256,text_len] c*Lt+t; style [256,50] c*50+t) as the cond
+            // inputs above.
+            f32_tensor tst = read_f32(model, "vector_estimator:tts.ttl.uncond_masker.text_special_token");   // [256]
+            f32_tensor skt = read_f32(model, "vector_estimator:tts.ttl.uncond_masker.style_key_special_token");   // [50,256] (t,c)
+            f32_tensor svt = read_f32(model, "vector_estimator:tts.ttl.uncond_masker.style_value_special_token"); // [50,256] (t,c)
+            std::vector<float> text_u((size_t)256 * text_len);
+            for (int c = 0; c < 256; ++c) for (int t = 0; t < text_len; ++t) text_u[(size_t)c*text_len+t] = tst.data[c];
+            std::vector<float> sv_u((size_t)256 * 50), sk_u((size_t)256 * 50);
+            for (int c = 0; c < 256; ++c) for (int t = 0; t < 50; ++t) {
+                sv_u[(size_t)c*50+t] = svt.data[(size_t)t*256+c];
+                sk_u[(size_t)c*50+t] = skt.data[(size_t)t*256+c];
+            }
+            ggml_backend_tensor_set(cache.text_in_u, text_u.data(), 0, text_u.size() * sizeof(float));
+            ggml_backend_tensor_set(cache.style_v_raw_in_u, sv_u.data(), 0, sv_u.size() * sizeof(float));
+            ggml_backend_tensor_set(cache.style_kctx_in_u, sk_u.data(), 0, sk_u.size() * sizeof(float));
+        }
 
         // RoPE positions + freq_factors.  theta is loaded from the model and
         // depends on L (sequence length); recompute per call.
@@ -4899,6 +5000,10 @@ struct vector_loop_one_graph_cache {
     ggml_tensor * text_in = nullptr;        // ne=[text_len, 256]
     ggml_tensor * style_v_raw_in = nullptr; // ne=[50, 256]
     ggml_tensor * style_kctx_in = nullptr;  // ne=[50, 256]
+    // CFG unconditional-pass inputs (v3 only; null when disabled).
+    ggml_tensor * text_in_u = nullptr;
+    ggml_tensor * style_v_raw_in_u = nullptr;
+    ggml_tensor * style_kctx_in_u = nullptr;
 
     // RoPE inputs (constant across steps).
     ggml_tensor * pos_q = nullptr;
@@ -4931,6 +5036,7 @@ void free_vector_loop_one_graph_cache(vector_loop_one_graph_cache & cache) {
     cache.total_steps = 0;
     cache.x0_in = cache.mask_in = cache.text_in = nullptr;
     cache.style_v_raw_in = cache.style_kctx_in = nullptr;
+    cache.text_in_u = cache.style_v_raw_in_u = cache.style_kctx_in_u = nullptr;
     cache.pos_q = cache.pos_k = cache.freq_factors_q = cache.freq_factors_k = nullptr;
     cache.t_emb_in.clear();
     cache.final_latent_out = nullptr;
@@ -4976,7 +5082,8 @@ bool supertonic_vector_loop_one_graph_ggml(const supertonic_model & model,
             // ggml nodes pre-Tier-2; post-Tier-2 it's ~928.  Round up to 8192/step
             // × total_steps = ~40k.  Plus the shared inputs (a few dozen) +
             // per-step temb input tensors.
-            const int MAX_NODES = 8192 * std::max(1, total_steps) + 256;
+            const int per_step_nodes = model.hparams.cfg_enabled() ? 16384 : 8192;
+            const int MAX_NODES = per_step_nodes * std::max(1, total_steps) + 256;
             const size_t buf_size = ggml_tensor_overhead() * (size_t) MAX_NODES +
                                      ggml_graph_overhead_custom(MAX_NODES, false);
             cache.buf.assign(buf_size, 0);
@@ -4995,6 +5102,14 @@ bool supertonic_vector_loop_one_graph_ggml(const supertonic_model & model,
             ggml_set_name(cache.style_v_raw_in, "loop_style_v"); ggml_set_input(cache.style_v_raw_in);
             cache.style_kctx_in = ggml_new_tensor_2d(cache.ctx, GGML_TYPE_F32, kv_style, text_C);
             ggml_set_name(cache.style_kctx_in, "loop_style_kctx"); ggml_set_input(cache.style_kctx_in);
+            if (model.hparams.cfg_enabled()) {
+                cache.text_in_u = ggml_new_tensor_2d(cache.ctx, GGML_TYPE_F32, text_len, text_C);
+                ggml_set_name(cache.text_in_u, "loop_text_in_u"); ggml_set_input(cache.text_in_u);
+                cache.style_v_raw_in_u = ggml_new_tensor_2d(cache.ctx, GGML_TYPE_F32, kv_style, text_C);
+                ggml_set_name(cache.style_v_raw_in_u, "loop_style_v_u"); ggml_set_input(cache.style_v_raw_in_u);
+                cache.style_kctx_in_u = ggml_new_tensor_2d(cache.ctx, GGML_TYPE_F32, kv_style, text_C);
+                ggml_set_name(cache.style_kctx_in_u, "loop_style_kctx_u"); ggml_set_input(cache.style_kctx_in_u);
+            }
 
             cache.pos_q = ggml_new_tensor_1d(cache.ctx, GGML_TYPE_I32, L);
             ggml_set_name(cache.pos_q, "loop_pos_q"); ggml_set_input(cache.pos_q);
@@ -5031,6 +5146,17 @@ bool supertonic_vector_loop_one_graph_ggml(const supertonic_model & model,
 
                 ggml_tensor * next = append_supertonic_vector_step_subgraph(
                     cache.ctx, cache.gf, model, inputs, L, text_len, total_steps);
+                if (model.hparams.cfg_enabled()) {
+                    vector_step_inputs inputs_u = inputs;
+                    inputs_u.text_in        = cache.text_in_u;
+                    inputs_u.style_v_raw_in = cache.style_v_raw_in_u;
+                    inputs_u.style_kctx_in  = cache.style_kctx_in_u;
+                    ggml_tensor * next_u = append_supertonic_vector_step_subgraph(
+                        cache.ctx, cache.gf, model, inputs_u, L, text_len, total_steps);
+                    next = ggml_sub(cache.ctx,
+                        ggml_scale(cache.ctx, next,   model.hparams.cfg_cond_scale),
+                        ggml_scale(cache.ctx, next_u, model.hparams.cfg_uncond_scale));
+                }
                 const std::string step_name = "loop_next_" + std::to_string(s);
                 ggml_set_name(next, step_name.c_str());
                 cur_latent = next;
@@ -5060,6 +5186,22 @@ bool supertonic_vector_loop_one_graph_ggml(const supertonic_model & model,
                                  style_v_raw_ptr->size() * sizeof(float));
         ggml_backend_tensor_set(cache.style_kctx_in, kctx_raw_ptr->data(), 0,
                                  kctx_raw_ptr->size() * sizeof(float));
+
+        if (model.hparams.cfg_enabled()) {
+            f32_tensor tst = read_f32(model, "vector_estimator:tts.ttl.uncond_masker.text_special_token");
+            f32_tensor skt = read_f32(model, "vector_estimator:tts.ttl.uncond_masker.style_key_special_token");
+            f32_tensor svt = read_f32(model, "vector_estimator:tts.ttl.uncond_masker.style_value_special_token");
+            std::vector<float> text_u((size_t)256 * text_len);
+            for (int c = 0; c < 256; ++c) for (int t = 0; t < text_len; ++t) text_u[(size_t)c*text_len+t] = tst.data[c];
+            std::vector<float> sv_u((size_t)256 * 50), sk_u((size_t)256 * 50);
+            for (int c = 0; c < 256; ++c) for (int t = 0; t < 50; ++t) {
+                sv_u[(size_t)c*50+t] = svt.data[(size_t)t*256+c];
+                sk_u[(size_t)c*50+t] = skt.data[(size_t)t*256+c];
+            }
+            ggml_backend_tensor_set(cache.text_in_u, text_u.data(), 0, text_u.size() * sizeof(float));
+            ggml_backend_tensor_set(cache.style_v_raw_in_u, sv_u.data(), 0, sv_u.size() * sizeof(float));
+            ggml_backend_tensor_set(cache.style_kctx_in_u, sk_u.data(), 0, sk_u.size() * sizeof(float));
+        }
 
         {
             std::vector<int32_t> pos_q_host(L);
@@ -5182,6 +5324,11 @@ bool supertonic_vector_step_ggml(const supertonic_model & model,
     try {
         std::vector<supertonic_trace_tensor> scalar_trace;
         std::vector<supertonic_trace_tensor> ggml_trace;
+        const int L = latent_len;
+        const int C = model.hparams.latent_channels;
+
+        // Conditional pass (text = real embeddings, style derived from
+        // `style_ttl` + `/Expand_output_0`).
         std::vector<float> next_tc;
         if (!supertonic_vector_trace_proj_ggml(model, noisy_latent, text_emb, text_len,
                                                style_ttl, latent_mask, latent_len,
@@ -5190,13 +5337,55 @@ bool supertonic_vector_step_ggml(const supertonic_model & model,
                                                false, false, &next_tc)) {
             return false;
         }
-        const int L = latent_len;
-        const int C = model.hparams.latent_channels;
         if (next_tc.size() != (size_t)L*C) throw std::runtime_error("bad ve_next_latent_tc size");
+
+        if (!model.hparams.cfg_enabled()) {
+            next_latent_out.assign((size_t)C*L, 0.0f);
+            for (int c = 0; c < C; ++c) {
+                for (int t = 0; t < L; ++t) {
+                    next_latent_out[(size_t)c*L + t] = next_tc[(size_t)t*C + c];
+                }
+            }
+            if (error) error->clear();
+            return true;
+        }
+
+        // Classifier-Free Guidance (Supertonic 3) — second, unconditional
+        // pass using the learned null text / style tokens, then combine.
+        // `next = noise + velocity/N` is affine in the velocity, and the
+        // exported guidance uses cond_scale - uncond_scale == 1, so combining
+        // the two integrated latents with the same coefficients reproduces
+        // `velocity = cs*v_cond - us*v_uncond` exactly (the residual
+        // `(1 - cs + us)*noise` term below covers any non-unit gap).
+        f32_tensor tst = read_f32(model, "vector_estimator:tts.ttl.uncond_masker.text_special_token");   // [256]
+        f32_tensor skt = read_f32(model, "vector_estimator:tts.ttl.uncond_masker.style_key_special_token");   // [50,256] (t,c)
+        f32_tensor svt = read_f32(model, "vector_estimator:tts.ttl.uncond_masker.style_value_special_token"); // [50,256] (t,c)
+        std::vector<float> text_u((size_t)256 * text_len);
+        for (int c = 0; c < 256; ++c) for (int t = 0; t < text_len; ++t) text_u[(size_t)c*text_len+t] = tst.data[c];
+        std::vector<float> sv_u((size_t)256 * 50), sk_u((size_t)256 * 50);
+        for (int c = 0; c < 256; ++c) for (int t = 0; t < 50; ++t) {
+            sv_u[(size_t)c*50+t] = svt.data[(size_t)t*256+c];
+            sk_u[(size_t)c*50+t] = skt.data[(size_t)t*256+c];
+        }
+        std::vector<float> next_tc_u;
+        if (!supertonic_vector_trace_proj_ggml(model, noisy_latent, text_u.data(), text_len,
+                                               /*style_ttl=*/nullptr, latent_mask, latent_len,
+                                               current_step, total_steps,
+                                               scalar_trace, ggml_trace, error,
+                                               false, false, &next_tc_u,
+                                               &sv_u, &sk_u)) {
+            return false;
+        }
+        if (next_tc_u.size() != (size_t)L*C) throw std::runtime_error("bad ve_next_latent_tc (uncond) size");
+
+        const float cs = model.hparams.cfg_cond_scale, us = model.hparams.cfg_uncond_scale;
+        const float kn = 1.0f - cs + us; // == 0 when cond_scale - uncond_scale == 1
         next_latent_out.assign((size_t)C*L, 0.0f);
         for (int c = 0; c < C; ++c) {
             for (int t = 0; t < L; ++t) {
-                next_latent_out[(size_t)c*L + t] = next_tc[(size_t)t*C + c];
+                float combined = cs * next_tc[(size_t)t*C + c] - us * next_tc_u[(size_t)t*C + c];
+                if (kn != 0.0f) combined += kn * noisy_latent[(size_t)c*L + t];
+                next_latent_out[(size_t)c*L + t] = combined;
             }
         }
         if (error) error->clear();

--- a/tts-cpp/test/test_supertonic_languages.cpp
+++ b/tts-cpp/test/test_supertonic_languages.cpp
@@ -1,0 +1,202 @@
+// QVAC-19305 — Supertonic v3 language-coverage tests.
+//
+// v3 widened the supported-language set from the v1/v2 5-language
+// bundle (en, ko, es, pt, fr) to a 31-language bundle plus the
+// language-agnostic `na` code (pass lang="na" when the source
+// language is unknown).  The authoritative list lives in
+// `scripts/convert-supertonic2-to-gguf.py` (`ARCH_LANGUAGES`) and is
+// shipped in the GGUF `supertonic.languages` array; the runtime
+// validates user-supplied codes against it in
+// `supertonic_preprocess_text(... supported_languages)`.
+//
+// Two layers of testing here:
+//
+//   1. Unit-level contract test (no GGUF, runs on `ctest -L unit`).
+//      `supertonic_preprocess_text` takes the supported-language
+//      vector directly, so we can pin the v3 contract without a
+//      model:
+//        - every v3 code (31 langs + `na`) is ACCEPTED and wrapped
+//          correctly in both `open_close` and `prefix` modes,
+//        - codes outside the active set are REJECTED (throw),
+//        - the built-in fallback (null supported set) still only
+//          accepts the legacy v1/v2 5-language bundle — so a
+//          v3-only code like `de`/`ja`/`na` is rejected there,
+//          proving the GGUF array (not the fallback) is what
+//          unlocks the new languages.
+//
+//   2. Fixture-level cross-check (requires GGUF).  When a model is
+//      passed, every code in the loaded `model.languages` must be
+//      accepted by the preprocessor against that same array, tying
+//      the converter's source-of-truth to the runtime validator.
+
+#include "supertonic_internal.h"
+
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace tts_cpp::supertonic::detail;
+
+namespace {
+
+int g_failures = 0;
+int g_checks   = 0;
+
+#define CHECK(cond) do {                                              \
+    ++g_checks;                                                       \
+    if (!(cond)) {                                                    \
+        ++g_failures;                                                 \
+        std::fprintf(stderr, "FAIL %s:%d  %s\n",                      \
+                     __FILE__, __LINE__, #cond);                      \
+    }                                                                 \
+} while (0)
+
+// Mirror of ARCH_LANGUAGES["supertonic3"] in the converter — 31
+// languages + the language-agnostic `na`.  Kept here verbatim so the
+// test pins the contract independently of any GGUF fixture.
+const std::vector<std::string> kV3Languages = {
+    "ar", "bg", "hr", "cs", "da", "nl", "en", "et", "fi", "fr", "de", "el",
+    "hi", "hu", "id", "it", "ja", "ko", "lv", "lt", "pl", "pt", "ro", "ru",
+    "sk", "sl", "es", "sv", "tr", "uk", "vi", "na",
+};
+
+// Mirror of ARCH_LANGUAGES["supertonic2"] — the legacy 5-language
+// bundle, which is also the built-in fallback allowlist.
+const std::vector<std::string> kV2Languages = {
+    "en", "ko", "es", "pt", "fr",
+};
+
+// Returns true if the preprocessor accepted `lang` (no throw),
+// false if it rejected it (threw the "invalid Supertonic language"
+// error).  Other exceptions are re-thrown so genuine bugs surface.
+bool accepts(const std::string & lang,
+             const std::string & wrap_mode,
+             const std::vector<std::string> * supported) {
+    try {
+        (void) supertonic_preprocess_text("hello world", lang, wrap_mode,
+                                          /*is_continuation=*/false, supported);
+        return true;
+    } catch (const std::exception &) {
+        return false;
+    }
+}
+
+void test_v3_languages_accepted() {
+    std::fprintf(stderr, "[v3 languages accepted + wrapped]\n");
+    for (const std::string & lang : kV3Languages) {
+        // open_close: "<lang>...</lang>".
+        CHECK(accepts(lang, "open_close", &kV3Languages));
+        const std::string oc = supertonic_preprocess_text(
+            "hello world", lang, "open_close", false, &kV3Languages);
+        const std::string open  = "<" + lang + ">";
+        const std::string close = "</" + lang + ">";
+        CHECK(oc.rfind(open, 0) == 0);
+        CHECK(oc.size() >= close.size() &&
+              oc.compare(oc.size() - close.size(), close.size(), close) == 0);
+
+        // prefix: "<lang>... " (trailing space, no close tag).
+        const std::string px = supertonic_preprocess_text(
+            "hello world", lang, "prefix", false, &kV3Languages);
+        CHECK(px.rfind(open, 0) == 0);
+        CHECK(!px.empty() && px.back() == ' ');
+
+        // none: no wrapping at all.
+        const std::string nn = supertonic_preprocess_text(
+            "hello world", lang, "none", false, &kV3Languages);
+        CHECK(nn.find('<') == std::string::npos);
+    }
+}
+
+void test_na_is_v3_only() {
+    std::fprintf(stderr, "[`na` accepted under v3, rejected by fallback]\n");
+    // The language-agnostic code is v3's headline addition.
+    CHECK(accepts("na", "open_close", &kV3Languages));
+    // It must NOT be accepted by the legacy fallback (null supported
+    // set) nor by the explicit v2 bundle.
+    CHECK(!accepts("na", "open_close", nullptr));
+    CHECK(!accepts("na", "open_close", &kV2Languages));
+}
+
+void test_unknown_codes_rejected() {
+    std::fprintf(stderr, "[unknown codes rejected]\n");
+    static const char * const kBogus[] = {
+        "xx", "zz", "qq", "english", "EN", "En", "es-419", "zh", "th", "",
+    };
+    for (const char * code : kBogus) {
+        CHECK(!accepts(code, "open_close", &kV3Languages));
+    }
+}
+
+void test_fallback_is_legacy_five() {
+    std::fprintf(stderr, "[built-in fallback = legacy v1/v2 bundle]\n");
+    // With a null supported set, only the legacy 5 are accepted.
+    for (const std::string & lang : kV2Languages) {
+        CHECK(accepts(lang, "open_close", nullptr));
+    }
+    // v3-only codes must be rejected by the fallback (they are only
+    // unlocked by the GGUF `supertonic.languages` array).
+    static const char * const kV3Only[] = {
+        "de", "ja", "ru", "ar", "hi", "vi", "uk", "na",
+    };
+    for (const char * code : kV3Only) {
+        CHECK(!accepts(code, "open_close", nullptr));
+    }
+    // Empty supported set behaves like null (falls back to legacy).
+    const std::vector<std::string> empty;
+    CHECK(accepts("en", "open_close", &empty));
+    CHECK(!accepts("de", "open_close", &empty));
+}
+
+void test_v3_superset_of_v2() {
+    std::fprintf(stderr, "[v3 set is a superset of v2]\n");
+    for (const std::string & lang : kV2Languages) {
+        bool found = false;
+        for (const std::string & v3 : kV3Languages) {
+            if (v3 == lang) { found = true; break; }
+        }
+        CHECK(found);
+    }
+    // Sanity: 31 languages + `na` == 32 entries.
+    CHECK(kV3Languages.size() == 32);
+}
+
+} // namespace
+
+int main(int argc, char ** argv) {
+    // Unit-level contract tests run unconditionally; no model.
+    test_v3_languages_accepted();
+    test_na_is_v3_only();
+    test_unknown_codes_rejected();
+    test_fallback_is_legacy_five();
+    test_v3_superset_of_v2();
+
+    // Fixture-level cross-check requires the GGUF: every code the
+    // model advertises must be accepted by the validator against the
+    // model's own array.
+    if (argc >= 2) {
+        std::fprintf(stderr, "[fixture] (loading %s)\n", argv[1]);
+        supertonic_model model;
+        if (load_supertonic_gguf(argv[1], model, /*n_gpu_layers=*/0, /*verbose=*/false)) {
+            std::fprintf(stderr, "  model advertises %zu languages\n",
+                         model.languages.size());
+            CHECK(!model.languages.empty());
+            const std::string wrap = model.hparams.language_wrap_mode.empty()
+                                         ? "open_close"
+                                         : model.hparams.language_wrap_mode;
+            for (const std::string & lang : model.languages) {
+                CHECK(accepts(lang, wrap, &model.languages));
+            }
+            free_supertonic_model(model);
+        } else {
+            std::fprintf(stderr, "  skip fixture: failed to load %s\n", argv[1]);
+        }
+    } else {
+        std::fprintf(stderr, "  (fixture skipped; pass MODEL.gguf to enable)\n");
+    }
+
+    std::fprintf(stderr,
+                 "test_supertonic_languages: %d / %d checks passed\n",
+                 g_checks - g_failures, g_checks);
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tts-cpp/test/test_supertonic_pipeline.cpp
+++ b/tts-cpp/test/test_supertonic_pipeline.cpp
@@ -88,6 +88,11 @@ int main(int argc, char ** argv) {
             throw std::runtime_error("vocoder failed: " + error);
         }
 
+        if (const char * dump = std::getenv("SUPERTONIC_DUMP_WAV")) {
+            npy_save_f32(dump, {(int) wav.size()}, wav.data());
+            fprintf(stderr, "dumped wav (%zu samples) -> %s\n", wav.size(), dump);
+        }
+
         const size_t n = std::min((size_t) wav.size(), wav_ref.n_elements());
         compare_stats s = compare_f32(wav.data(), npy_as_f32(wav_ref), n);
         print_compare("supertonic_pipeline_wav", s);


### PR DESCRIPTION
## QVAC-19305 — Supertonic v3 support

Adds the `supertonic3` arch end-to-end. v3 renumbered **every** auto-generated ONNX node id (`onnx::MatMul_`/`Conv_`/`PRelu_`), doubled the vector-estimator text cross-attention (**4 → 8 heads**, width 256 → 512), turned the speech-prompted-attention key into a live (non-pre-folded) tensor, and widened the language bundle to **31 codes + the language-agnostic `na`**. The runtime keeps binding weights by stable names via converter-emitted aliases, so the bulk of the inference code is untouched.

### Changes

1. **Converter (`convert-supertonic2-to-gguf.py`)** — derive stable canonical names from adjacent bias/node names and emit `supertonic.source_aliases` / `source_alias_targets`; add **bridge aliases** mapping v2 logical `onnx::MatMul_` ids → v3 physical tensors (keeps the ~90 vector_estimator refs untouched); **materialize** the v3 text-encoder `tanh_k` constant via onnxruntime and alias the relocated `/Expand_output_0`; `ARCH_LANGUAGES["supertonic3"]` = 31 langs + `na`.
2. **Loader (`supertonic_gguf.cpp`, `supertonic_internal.h`)** — accept arch `supertonic3`; load `vector_text_attn_heads`; register canonical + bridge aliases into `model.source_tensors`; point vocoder embed/head refs at canonical node names.
3. **Runtime text_encoder** — 6 speech-prompted-attention matmuls → canonical names.
4. **Runtime vector_estimator** — thread `vector_text_attn_heads` (4→8) and width `A = H*64` through the CPU, graph, one-graph and parity-trace paths (no string-ref edits; bridge aliases handle the binding).
5. **Preprocess** — validate language codes against the GGUF `supertonic.languages` array; legacy 5-language built-in kept as fallback.
6. **Tests** — new CPU-only `test_supertonic_languages` pinning the v3 language contract.

F16 / pre-transpose need **no change**: both predicates are name-pattern based (`onnx::MatMul_<digits>` / `:onnx::MatMul_` substring), so v3 primaries are promoted/pre-transposed as-is.

### Verification

Built standalone against the `ggml-speech` vcpkg port (qvac-ext-ggml@speech) on arm64-osx / Metal.

| Check | Result |
|---|---|
| Full `tts-cpp` lib compile (incl. all v3 changes) | ✅ clean |
| Unit suite (`ctest -L unit`) | ✅ 26/26 |
| `test-supertonic-languages` | ✅ 226/226 checks (31+`na` accepted/wrapped, unknown rejected, fallback = legacy 5) |
| `test-metal-ops` (gpu) | ✅ |

Fixture/parity tests (31) are skipped here — they need a `supertonic.gguf` + reference `.npy` not in the repo; numerical v3 parity will be validated once a v3 GGUF is produced with the updated converter. The `mtl-synth-*` failures in a full run are pre-existing and unrelated (Chatterbox MTL, missing `T3.gguf`/`S3GEN.gguf`).

### Hygiene

- No `QVAC-####` refs in source comments.
- Comments explain only non-obvious intent (head-count threading, alias/bridge rationale).