### PR TITLE
QVAC-20484 tts-cpp: fix Chatterbox streaming TTFT slowdown (sliding-window S3Gen + per-sentence Engine segmentation)

### DIFF
--- a/tts-cpp/CMakeLists.txt
+++ b/tts-cpp/CMakeLists.txt
@@ -726,6 +726,28 @@ if (TTS_CPP_BUILD_TESTS)
         ARGS     "${_tcb_s3gen_gguf}" "${_tcb_streaming_ref}"
         REQUIRES "${_tcb_s3gen_gguf}" "${_tcb_streaming_ref}")
 
+    # Pure sentence-splitter unit test (no model/fixture) -- always runs.
+    # Pins split_text_for_tts after it was lifted into the shared
+    # text_preprocess unit (used by both the CLI and the Engine).
+    add_executable(test-text-split test/test_text_split.cpp)
+    target_link_libraries(test-text-split PRIVATE tts-cpp)
+    target_include_directories(test-text-split PRIVATE src)
+    tts_cpp_apply_ccache(test-text-split)
+    tts_cpp_register_test(test-text-split LABEL "cpu")
+
+    # Engine-level streaming-callback contract test for the per-sentence
+    # segmentation path (Fix #2): monotonic global chunk_index, single final
+    # is_last, result.pcm == concat(callbacks), accumulated stats.  Gated on
+    # the chatterbox Turbo T3 + S3Gen GGUFs.
+    add_executable(test-chatterbox-engine-stream test/test_chatterbox_engine_stream.cpp)
+    target_link_libraries(test-chatterbox-engine-stream PRIVATE tts-cpp ggml tts-cpp-backend-defs)
+    target_include_directories(test-chatterbox-engine-stream PRIVATE ggml/include src include)
+    tts_cpp_apply_ccache(test-chatterbox-engine-stream)
+    tts_cpp_register_test(test-chatterbox-engine-stream
+        LABEL    "fixture"
+        ARGS     "${_tcb_t3_turbo_gguf}" "${_tcb_s3gen_gguf}"
+        REQUIRES "${_tcb_t3_turbo_gguf}" "${_tcb_s3gen_gguf}")
+
     # CPU-side persistent-cache validation.
     # Exercises the time_mlp / time_emb / cfm_estimator / weight_mirror
     # caches that amortise per-synth overhead on the multilingual CPU

--- a/tts-cpp/include/tts-cpp/chatterbox/engine.h
+++ b/tts-cpp/include/tts-cpp/chatterbox/engine.h
@@ -217,6 +217,22 @@ struct EngineOptions {
     // behaviour).  Typical: 25-50 (one or two chunks of context).
     int stream_left_context_tokens = 0;
 
+    // Sentence-level auto-split (parity with the CLI's --max-sentence-chars).
+    // When > 0, synthesize() splits `text` into segments of at most this many
+    // bytes and runs T3 + S3Gen independently per sentence, bounding the T3
+    // sequence length (prosody + O(N^2) decode cost) and letting first audio
+    // start after the first sentence instead of the whole paragraph.  Adopted
+    // only when it yields >1 segment (else the whole text is one segment).
+    // 0 = disabled: a single pass over the whole text == legacy behaviour.
+    // The CLI uses 180.
+    int max_sentence_chars = 0;
+    // Raised-cosine crossfade (ms) applied between sentence segments on the
+    // non-streaming (batch) path to mask seams.  Only consulted when
+    // max_sentence_chars actually splits into >1 segment.  Ignored on the
+    // streaming-callback path, which stays gapless so the documented
+    // `result.pcm == concat(callback chunks)` invariant holds.
+    int crossfade_ms = 30;
+
     // Pass-through of the CLI's --verbose behaviour: per-stage wall times
     // on stderr.  Errors always go through regardless of this flag.
     bool verbose = false;
@@ -225,8 +241,14 @@ struct EngineOptions {
 // Per-chunk PCM callback.  Receives a pointer to `samples` consecutive
 // 24 kHz float32 mono samples.  The buffer is owned by the engine and
 // must not be retained past the callback; copy out if you need the data.
-//   `chunk_index`  0-based index of the chunk within the current utterance.
-//   `is_last`      true on the final chunk (after which synthesize() returns).
+//   `chunk_index`  0-based; increments by exactly 1 per chunk across the whole
+//                  synthesize() call.  With max_sentence_chars auto-split it
+//                  keeps counting across sentence segments (it does NOT reset
+//                  per sentence); with auto-split off there is one segment, so
+//                  it is the plain per-utterance index as before.  No synthetic
+//                  silence chunk is ever emitted between segments.
+//   `is_last`      true only on the final chunk of the final segment (after
+//                  which synthesize() returns).
 // Throwing from this callback aborts synthesis (the exception propagates
 // out of synthesize()).
 using StreamCallback = std::function<void(

--- a/tts-cpp/include/tts-cpp/chatterbox/engine.h
+++ b/tts-cpp/include/tts-cpp/chatterbox/engine.h
@@ -209,6 +209,14 @@ struct EngineOptions {
     int stream_first_chunk_tokens = 0;
     int stream_cfm_steps          = 0;
 
+    // Sliding-window S3Gen: retain only this many already-emitted speech
+    // tokens of left context per chunk instead of re-synthesizing the whole
+    // cumulative prefix.  Bounds per-chunk encoder+CFM cost — the cumulative
+    // prefix otherwise makes per-chunk cost grow with elapsed output (~O(N^2)
+    // over a long utterance / paragraph).  0 = disabled (legacy cumulative
+    // behaviour).  Typical: 25-50 (one or two chunks of context).
+    int stream_left_context_tokens = 0;
+
     // Pass-through of the CLI's --verbose behaviour: per-stage wall times
     // on stderr.  Errors always go through regardless of this flag.
     bool verbose = false;

--- a/tts-cpp/src/chatterbox_cli.cpp
+++ b/tts-cpp/src/chatterbox_cli.cpp
@@ -61,6 +61,7 @@
 #include "campplus.h"
 #include "s3tokenizer.h"
 #include "gguf.h"
+#include "text_preprocess.h"
 
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -127,133 +128,11 @@ static void stream_emit_pcm_stdout(const std::vector<float> & wav) {
     std::fflush(stdout);
 }
 
-// Split `text` into TTS-friendly segments of at most `max_chars` characters.
-//
-// Motivation: Chatterbox Turbo's T3 was trained on utterances of 5–15 s and
-// degrades (prosody drift, hallucinated phonemes, timbre wandering) on much
-// longer autoregressive outputs.  Reproducible on every backend (ggml / ONNX
-// / upstream Python).  The only reliable fix is sentence-level segmentation
-// above the model.
-//
-// The splitter does three passes:
-//   1. Break at `. ? !` followed by whitespace / EOF.
-//   2. For any sentence longer than `max_chars`, break further at `, : ;`
-//      (preferring boundaries past max_chars/2 so we don't fragment into
-//      unpronouncable stubs).  Last-resort: hard-break every max_chars.
-//   3. Greedily merge consecutive short fragments forward while their
-//      combined length stays <= max_chars, so very short sentences ride
-//      with their neighbours rather than stand alone.
-//
-// Abbreviations like "e.g." are not treated specially; in practice the
-// greedy merge pass absorbs false splits on them back into the next segment.
-static std::vector<std::string> split_text_for_tts(const std::string & text, int max_chars) {
-    std::vector<std::string> out;
-    if (text.empty() || max_chars <= 0) { out.push_back(text); return out; }
-
-    auto is_ws = [](unsigned char c) { return std::isspace(c) != 0; };
-
-    // Pass 1: sentence split.
-    std::vector<std::string> sentences;
-    {
-        std::string cur;
-        size_t i = 0;
-        while (i < text.size()) {
-            cur += text[i];
-            const char c = text[i];
-            const bool at_end = (i + 1 == text.size());
-            const bool nx_ws  = !at_end && is_ws((unsigned char)text[i + 1]);
-            if ((c == '.' || c == '?' || c == '!') && (at_end || nx_ws)) {
-                size_t j = i + 1;
-                while (j < text.size() && is_ws((unsigned char)text[j])) { cur += text[j]; ++j; }
-                sentences.push_back(cur);
-                cur.clear();
-                i = j;
-            } else {
-                ++i;
-            }
-        }
-        if (!cur.empty()) sentences.push_back(cur);
-    }
-
-    // Pass 2: refine any sentence longer than max_chars.
-    std::vector<std::string> refined;
-    refined.reserve(sentences.size());
-    for (auto & s : sentences) {
-        if ((int)s.size() <= max_chars) { refined.push_back(std::move(s)); continue; }
-        std::string acc;
-        size_t k = 0;
-        while (k < s.size()) {
-            acc += s[k];
-            const char c = s[k];
-            const bool nx_ws = (k + 1 < s.size()) && is_ws((unsigned char)s[k + 1]);
-            const bool soft_break = (c == ',' || c == ':' || c == ';') && nx_ws &&
-                                    (int)acc.size() > max_chars / 2;
-            if (soft_break) {
-                size_t j = k + 1;
-                while (j < s.size() && is_ws((unsigned char)s[j])) { acc += s[j]; ++j; }
-                refined.push_back(acc);
-                acc.clear();
-                k = j;
-                continue;
-            }
-            if ((int)acc.size() >= max_chars) {
-                // Last-resort hard break at a space if we can find one in the
-                // tail quarter; otherwise just cut.
-                size_t back = acc.size();
-                while (back > (size_t)(max_chars * 3 / 4) && !is_ws((unsigned char)acc[back - 1])) --back;
-                if (back <= (size_t)(max_chars / 2)) back = acc.size();
-                refined.push_back(acc.substr(0, back));
-                acc.erase(0, back);
-            }
-            ++k;
-        }
-        if (!acc.empty()) refined.push_back(acc);
-    }
-
-    // Pass 3: greedy forward merge of short fragments.
-    for (auto & s : refined) {
-        if (!out.empty() && (int)(out.back().size() + s.size()) <= max_chars) {
-            out.back() += s;
-        } else {
-            out.push_back(std::move(s));
-        }
-    }
-
-    // Strip trailing whitespace per segment.
-    for (auto & s : out) {
-        while (!s.empty() && is_ws((unsigned char)s.back())) s.pop_back();
-    }
-    // Drop empty segments (paranoia).
-    out.erase(std::remove_if(out.begin(), out.end(),
-                             [](const std::string & s) { return s.empty(); }),
-              out.end());
-    if (out.empty()) out.push_back(text);
-    return out;
-}
-
-// Append `src` PCM to `dst`, crossfading the last `fade_ms` of `dst` with the
-// leading `fade_ms` of `src` via a raised-cosine ramp.  Removes clicks at
-// segment seams in auto-split mode.
-static void append_pcm_crossfade(std::vector<float> & dst, const std::vector<float> & src,
-                                 int sr, int fade_ms) {
-    if (src.empty()) return;
-    if (dst.empty() || fade_ms <= 0) {
-        dst.insert(dst.end(), src.begin(), src.end());
-        return;
-    }
-    int fade_n = sr * fade_ms / 1000;
-    fade_n = std::min(fade_n, (int)dst.size());
-    fade_n = std::min(fade_n, (int)src.size());
-    if (fade_n <= 0) { dst.insert(dst.end(), src.begin(), src.end()); return; }
-
-    const size_t ofs = dst.size() - fade_n;
-    for (int i = 0; i < fade_n; ++i) {
-        const float t = (float)(i + 1) / (float)(fade_n + 1);
-        const float w = 0.5f * (1.0f - std::cos((float)M_PI * t));  // 0 → 1 cosine ramp
-        dst[ofs + i] = dst[ofs + i] * (1.0f - w) + src[i] * w;
-    }
-    dst.insert(dst.end(), src.begin() + fade_n, src.end());
-}
+// split_text_for_tts and append_pcm_crossfade now live in text_preprocess
+// (shared with the Engine streaming path); import them so the call sites in
+// this file stay unqualified.
+using tts_cpp::chatterbox::text_preprocess::split_text_for_tts;
+using tts_cpp::chatterbox::text_preprocess::append_pcm_crossfade;
 
 // Save the five voice-conditioning tensors to a directory as .npy so later
 // runs can reuse them via --ref-dir (no --reference-audio needed), skipping

--- a/tts-cpp/src/chatterbox_cli.cpp
+++ b/tts-cpp/src/chatterbox_cli.cpp
@@ -421,6 +421,14 @@ struct cli_params {
     // to 2 (matches Python's meanflow); setting 1 halves CFM cost at the
     // price of a bit of extra high-frequency noise.
     int32_t stream_cfm_steps          = 0;
+    // Streaming S3Gen sliding-window: number of already-emitted speech tokens
+    // of left context to retain when synthesizing each chunk.  When > 0, chunk
+    // k feeds S3Gen only [chunk_start - N, chunk_end) instead of the full
+    // [0, chunk_end) prefix, so per-chunk encoder+CFM cost stays bounded.  The
+    // cumulative prefix otherwise makes per-chunk cost grow with elapsed output
+    // (O(N^2) over a segment).  0 = disabled (exact legacy cumulative
+    // behaviour).  Larger N preserves more attention context at the chunk seam.
+    int32_t stream_left_context_tokens = 0;
     // Override CFM Euler step count for non-streaming synthesis.  Defaults
     // to 0 (= use the GGUF's `n_timesteps`: 10 for Multilingual standard
     // CFM, 2 for Turbo's meanflow).  Lowering N (e.g. 7-8 on Multilingual)
@@ -590,6 +598,10 @@ static void print_usage(const char * argv0) {
     fprintf(stderr, "  --stream-first-chunk-tokens N  Override first-chunk size to minimise first-audio\n");
     fprintf(stderr, "                          latency.  Typical value: 10-15.  (default: 0 = same\n");
     fprintf(stderr, "                          as --stream-chunk-tokens)\n");
+    fprintf(stderr, "  --stream-left-context-tokens N  Sliding-window S3Gen: keep only N tokens of left\n");
+    fprintf(stderr, "                          context per chunk instead of the whole prefix, bounding\n");
+    fprintf(stderr, "                          per-chunk encoder+CFM cost (fixes the O(N^2) streaming\n");
+    fprintf(stderr, "                          slowdown).  0 = disabled (default).  Try 25-50.\n");
     fprintf(stderr, "  --stream-cfm-steps N    CFM Euler step count per chunk.  Python uses 2 for\n");
     fprintf(stderr, "                          meanflow; 1 halves CFM cost.  (default: 0 = 2)\n");
     fprintf(stderr, "  --cfm-steps N           Non-streaming CFM Euler step count.  Multilingual's\n");
@@ -781,6 +793,7 @@ static bool parse_args(int argc, char ** argv, cli_params & params) {
         else if (arg == "--stream-chunk-tokens")       { if (!parse_int("--stream-chunk-tokens",       params.stream_chunk_tokens))       return false; }
         else if (arg == "--stream-first-chunk-tokens") { if (!parse_int("--stream-first-chunk-tokens", params.stream_first_chunk_tokens)) return false; }
         else if (arg == "--stream-cfm-steps")          { if (!parse_int("--stream-cfm-steps",          params.stream_cfm_steps))          return false; }
+        else if (arg == "--stream-left-context-tokens"){ if (!parse_int("--stream-left-context-tokens", params.stream_left_context_tokens)) return false; }
         else if (arg == "--cfm-steps")                 { if (!parse_int("--cfm-steps",                 params.cfm_steps))                 return false; }
         else if (arg == "--input-file")       { auto v = next("--input-file");       if (!v) return false; params.input_file = v; }
         else if (arg == "--input-eof-marker") { auto v = next("--input-eof-marker"); if (!v) return false; params.input_eof_marker = v; }
@@ -1723,7 +1736,13 @@ int tts_cpp_cli_main(int argc, char ** argv) {
 
                     const int end    = boundaries[k];
                     const bool is_last = (end == total_n);
-                    std::vector<int32_t> toks(seg_toks.begin(), seg_toks.begin() + end);
+                    // Sliding left-context window (see --stream-left-context-tokens):
+                    // feed S3Gen only [win_start, end) so per-chunk cost is bounded.
+                    const int L_ctx     = params.stream_left_context_tokens;
+                    const int win_start = (L_ctx > 0)
+                                        ? std::max(0, boundaries[k - 1] - L_ctx) : 0;
+                    std::vector<int32_t> toks(seg_toks.begin() + win_start,
+                                              seg_toks.begin() + end);
 
                     s3gen_synthesize_opts copts = opts;
                     std::vector<float> chunk_pcm;
@@ -1731,7 +1750,7 @@ int tts_cpp_cli_main(int argc, char ** argv) {
                     copts.pcm_out                  = &chunk_pcm;
                     copts.append_lookahead_silence = false;
                     copts.finalize                 = is_last;
-                    copts.skip_mel_frames          = prev_mels_emitted;
+                    copts.skip_mel_frames          = prev_mels_emitted - 2 * win_start;
                     copts.apply_trim_fade          = (k == 1);
                     copts.hift_cache_source        = hift_cache_source;
                     std::vector<float> tail_out;
@@ -2424,7 +2443,13 @@ int tts_cpp_cli_main(int argc, char ** argv) {
                     for (int k = 1; k < (int)boundaries.size(); ++k) {
                         const int end    = boundaries[k];
                         const bool is_last_in_seg = (end == total_n);
-                        std::vector<int32_t> toks(seg_toks.begin(), seg_toks.begin() + end);
+                        // Sliding left-context window (see --stream-left-context-tokens):
+                        // feed S3Gen only [win_start, end) so per-chunk cost is bounded.
+                        const int L_ctx     = params.stream_left_context_tokens;
+                        const int win_start = (L_ctx > 0)
+                                            ? std::max(0, boundaries[k - 1] - L_ctx) : 0;
+                        std::vector<int32_t> toks(seg_toks.begin() + win_start,
+                                                  seg_toks.begin() + end);
 
                         s3gen_synthesize_opts copts = opts;
                         std::vector<float> chunk_pcm;
@@ -2432,7 +2457,7 @@ int tts_cpp_cli_main(int argc, char ** argv) {
                         copts.pcm_out                   = &chunk_pcm;
                         copts.append_lookahead_silence  = false;
                         copts.finalize                  = is_last_in_seg;
-                        copts.skip_mel_frames           = prev_mels_emitted;
+                        copts.skip_mel_frames           = prev_mels_emitted - 2 * win_start;
                         // First chunk of EACH segment gets trim_fade, masking
                         // HiFT's per-utterance resnet cold start.
                         copts.apply_trim_fade           = (k == 1);

--- a/tts-cpp/src/chatterbox_engine.cpp
+++ b/tts-cpp/src/chatterbox_engine.cpp
@@ -16,6 +16,7 @@
 #include "npy.h"
 #include "t3_mtl.h"
 #include "tts-cpp/chatterbox/s3gen_pipeline.h"
+#include "text_preprocess.h"
 #include "voice_encoder.h"
 #include "voice_features.h"
 
@@ -582,8 +583,12 @@ struct Engine::Impl {
         sopts.cancel_flag = &cancel_flag;
     }
 
-    SynthesisResult synthesize_batch(const std::vector<int32_t> & speech_tokens,
-                                     SynthesisResult && partial) {
+    // Renders ONE segment in batch (non-streaming) mode, appending its PCM
+    // into result.pcm (crossfaded into the previous segment's tail when not
+    // the first) and accumulating stats.  All per-segment s3gen state is local
+    // to this call, so consecutive calls reset naturally.
+    void synthesize_batch_segment(const std::vector<int32_t> & speech_tokens,
+                                  SynthesisResult & result) {
         s3gen_synthesize_opts sopts;
         fill_common_s3gen_opts(sopts);
         sopts.cfm_steps = opts.cfm_steps;
@@ -607,8 +612,8 @@ struct Engine::Impl {
             !opts.reference_audio.empty() || !opts.voice_dir.empty();
         sopts.apply_trim_fade = has_voice_override;
 
-        SynthesisResult result = std::move(partial);
-        sopts.pcm_out = &result.pcm;
+        std::vector<float> seg_pcm;
+        sopts.pcm_out = &seg_pcm;
 
         const auto s3_t0 = std::chrono::steady_clock::now();
         const int rc = s3gen_synthesize_to_wav(speech_tokens, sopts);
@@ -621,23 +626,32 @@ struct Engine::Impl {
                                      + std::to_string(rc));
         }
 
-        result.sample_rate   = 24000;
-        result.t3_tokens     = (int) speech_tokens.size();
-        result.audio_samples = (int) result.pcm.size();
-        result.s3gen_ms      = std::chrono::duration<double, std::milli>(s3_t1 - s3_t0).count();
-        return result;
+        // First segment: result.pcm is empty, so this is a plain append.
+        // Later segments: raised-cosine crossfade the seam (a no-op when
+        // crossfade_ms == 0).  Only the batch path crossfades; the streaming
+        // path stays gapless to preserve result.pcm == concat(callbacks).
+        tts_cpp::chatterbox::text_preprocess::append_pcm_crossfade(
+            result.pcm, seg_pcm, 24000, opts.crossfade_ms);
+        result.t3_tokens += (int) speech_tokens.size();
+        result.s3gen_ms  += std::chrono::duration<double, std::milli>(s3_t1 - s3_t0).count();
     }
 
-    // Ports main.cpp's --stream-chunk-tokens loop.  Splits speech_tokens
-    // into chunks of stream_chunk_tokens (with an optional smaller first
-    // chunk), carries `hift_cache_source` and `skip_mel_frames` across
-    // chunks for phase-continuous seams, and invokes `on_chunk` with
-    // each chunk's PCM as it's produced.  Accumulates the full PCM in
-    // the returned SynthesisResult so batch callers get the same shape.
-    SynthesisResult synthesize_streaming(
+    // Renders ONE segment in streaming mode: chunks speech_tokens, invokes
+    // on_chunk per chunk (global_chunk_idx is monotonic across segments;
+    // is_last fires only on the final chunk of the final segment), and
+    // plain-concatenates each chunk's PCM into result.pcm so the documented
+    // `result.pcm == concat(callback chunks)` invariant holds.  boundaries,
+    // win_start, hift_cache_source and prev_mels_emitted are all function-local
+    // so per-segment reset is automatic -- this is load-bearing for the
+    // skip_mel_frames = prev_mels_emitted - 2*win_start arithmetic, which is
+    // only correct because BOTH terms are segment-local.
+    void synthesize_streaming_segment(
         const std::vector<int32_t> & speech_tokens,
         const StreamCallback & on_chunk,
-        SynthesisResult && partial) {
+        SynthesisResult & result,
+        bool is_first_segment,
+        bool is_last_segment,
+        int & global_chunk_idx) {
 
         std::vector<int32_t> seg_toks = speech_tokens;
         for (int i = 0; i < kS3GenLookaheadTokens; ++i) {
@@ -646,7 +660,10 @@ struct Engine::Impl {
         const int total_n = (int) seg_toks.size();
 
         const int chunk_n       = opts.stream_chunk_tokens;
-        const int first_chunk_n = opts.stream_first_chunk_tokens > 0
+        // The smaller first chunk minimises first-audio latency, but only for
+        // the very first segment; later segments use the full chunk size for
+        // their first chunk (matches the CLI's per-segment behaviour).
+        const int first_chunk_n = (is_first_segment && opts.stream_first_chunk_tokens > 0)
                                     ? opts.stream_first_chunk_tokens
                                     : chunk_n;
 
@@ -668,9 +685,6 @@ struct Engine::Impl {
 
         std::vector<float> hift_cache_source;
         int prev_mels_emitted = 0;
-
-        SynthesisResult result = std::move(partial);
-        result.pcm.clear();
 
         const int n_chunks = (int) boundaries.size() - 1;
         double s3gen_ms_total = 0.0;
@@ -699,6 +713,8 @@ struct Engine::Impl {
             copts.finalize                  = is_last_in_seg;
             // Drop the already-emitted left-context mels (2 per token) still
             // inside the window; reduces to prev_mels_emitted when win_start==0.
+            // Correct only because prev_mels_emitted AND win_start are both
+            // segment-local (reset each call).
             copts.skip_mel_frames           = prev_mels_emitted - 2 * win_start;
             copts.apply_trim_fade           = (k == 1);
             copts.hift_cache_source         = hift_cache_source;
@@ -722,7 +738,12 @@ struct Engine::Impl {
             }
             s3gen_ms_total += std::chrono::duration<double, std::milli>(s3_t1 - s3_t0).count();
 
-            on_chunk(chunk_pcm.data(), chunk_pcm.size(), k - 1, is_last_in_seg);
+            // is_last is true only on the final chunk of the final segment.
+            // chunk_index is the global monotonic counter (post-incremented so
+            // the first chunk is index 0, matching the single-segment legacy).
+            const bool is_final_chunk = is_last_in_seg && is_last_segment;
+            on_chunk(chunk_pcm.data(), chunk_pcm.size(), global_chunk_idx, is_final_chunk);
+            ++global_chunk_idx;
 
             result.pcm.insert(result.pcm.end(), chunk_pcm.begin(), chunk_pcm.end());
             hift_cache_source = std::move(tail_out);
@@ -730,11 +751,8 @@ struct Engine::Impl {
             prev_mels_emitted += (int)(chunk_samples / 480);
         }
 
-        result.sample_rate   = 24000;
-        result.t3_tokens     = (int) speech_tokens.size();
-        result.audio_samples = (int) result.pcm.size();
-        result.s3gen_ms      = s3gen_ms_total;
-        return result;
+        result.t3_tokens += (int) speech_tokens.size();
+        result.s3gen_ms  += s3gen_ms_total;
     }
 
     SynthesisResult synthesize(const std::string & text,
@@ -744,19 +762,53 @@ struct Engine::Impl {
         }
         cancel_flag.store(false, std::memory_order_relaxed);
 
-        const auto t3_t0 = std::chrono::steady_clock::now();
-        std::vector<int32_t> speech_tokens = run_t3(text);
-        const auto t3_t1 = std::chrono::steady_clock::now();
+        // Sentence-level auto-split (parity with the CLI).  Adopt the split
+        // only when it yields >1 segment; otherwise treat the whole text as a
+        // single segment -- which, at max_sentence_chars == 0, reproduces the
+        // legacy single-pass behaviour byte-for-byte (one run_t3, chunk_index
+        // 0..n-1, is_last on the final chunk).
+        std::vector<std::string> segments;
+        if (opts.max_sentence_chars > 0) {
+            auto segs = tts_cpp::chatterbox::text_preprocess::split_text_for_tts(
+                text, opts.max_sentence_chars);
+            if (segs.size() > 1) segments = std::move(segs);
+        }
+        if (segments.empty()) segments.push_back(text);
 
+        // S3Gen weights finish loading on a background thread (usually already
+        // joined in the constructor); ensure they're ready before any S3Gen.
         wait_for_preload(s3gen_preload_thread);
 
-        SynthesisResult partial;
-        partial.t3_ms = std::chrono::duration<double, std::milli>(t3_t1 - t3_t0).count();
-
         const bool use_streaming = on_chunk && opts.stream_chunk_tokens > 0;
-        return use_streaming
-            ? synthesize_streaming(speech_tokens, on_chunk, std::move(partial))
-            : synthesize_batch(speech_tokens, std::move(partial));
+
+        SynthesisResult result;
+        result.sample_rate   = 24000;
+        int global_chunk_idx = 0;  // monotonic across all segments
+
+        for (size_t si = 0; si < segments.size(); ++si) {
+            // Bound cancel latency to a sentence boundary (run_t3 and the
+            // chunk loop also poll cancel_flag internally).
+            if (cancel_flag.load(std::memory_order_relaxed)) {
+                throw std::runtime_error("Engine: synthesis cancelled");
+            }
+            const auto t3_t0 = std::chrono::steady_clock::now();
+            std::vector<int32_t> speech_tokens = run_t3(segments[si]);
+            const auto t3_t1 = std::chrono::steady_clock::now();
+            result.t3_ms += std::chrono::duration<double, std::milli>(t3_t1 - t3_t0).count();
+
+            if (use_streaming) {
+                synthesize_streaming_segment(
+                    speech_tokens, on_chunk, result,
+                    /*is_first_segment=*/si == 0,
+                    /*is_last_segment=*/si + 1 == segments.size(),
+                    global_chunk_idx);
+            } else {
+                synthesize_batch_segment(speech_tokens, result);
+            }
+        }
+
+        result.audio_samples = (int) result.pcm.size();
+        return result;
     }
 
     SynthesisResult synthesize(const std::string & text) {

--- a/tts-cpp/src/chatterbox_engine.cpp
+++ b/tts-cpp/src/chatterbox_engine.cpp
@@ -681,7 +681,15 @@ struct Engine::Impl {
             }
             const int end              = boundaries[k];
             const bool is_last_in_seg  = (end == total_n);
-            std::vector<int32_t> toks(seg_toks.begin(), seg_toks.begin() + end);
+            // Sliding left-context window: feed S3Gen only [win_start, end)
+            // instead of the whole [0, end) prefix so per-chunk encoder+CFM
+            // cost stays bounded.  The cumulative prefix otherwise makes
+            // per-chunk cost grow with elapsed output (~O(N^2) over the
+            // utterance).  L == 0 preserves the exact legacy cumulative slice.
+            const int L_ctx     = opts.stream_left_context_tokens;
+            const int win_start = (L_ctx > 0) ? std::max(0, boundaries[k - 1] - L_ctx) : 0;
+            std::vector<int32_t> toks(seg_toks.begin() + win_start,
+                                      seg_toks.begin() + end);
 
             s3gen_synthesize_opts copts;
             fill_common_s3gen_opts(copts);
@@ -689,7 +697,9 @@ struct Engine::Impl {
             copts.pcm_out                   = &chunk_pcm;
             copts.append_lookahead_silence  = false;
             copts.finalize                  = is_last_in_seg;
-            copts.skip_mel_frames           = prev_mels_emitted;
+            // Drop the already-emitted left-context mels (2 per token) still
+            // inside the window; reduces to prev_mels_emitted when win_start==0.
+            copts.skip_mel_frames           = prev_mels_emitted - 2 * win_start;
             copts.apply_trim_fade           = (k == 1);
             copts.hift_cache_source         = hift_cache_source;
             std::vector<float> tail_out;

--- a/tts-cpp/src/chatterbox_tts.cpp
+++ b/tts-cpp/src/chatterbox_tts.cpp
@@ -2509,7 +2509,8 @@ int s3gen_synthesize_to_wav(
     vlog("Running encoder (T=%d)...\n", n_total);
     double encoder_t0 = now_ms();
     std::vector<float> mu_T = run_encoder(m, input_embed, n_total, D);
-    vlog("  [encoder] %.1f ms\n", now_ms() - encoder_t0);
+    double prof_encoder_ms = now_ms() - encoder_t0;
+    vlog("  [encoder] %.1f ms\n", prof_encoder_ms);
     int T_mu = 2 * n_total;
     vlog("  encoder output: (%d, 80) = %zu floats\n", T_mu, mu_T.size());
 
@@ -2854,7 +2855,8 @@ int s3gen_synthesize_to_wav(
             for (size_t i = 0; i < z.size(); ++i) z[i] = z[i] + dt * dxdt[i];
         }
     }
-    vlog("  [cfm_total] %.1f ms\n", now_ms() - cfm_t0);
+    double prof_cfm_ms = now_ms() - cfm_t0;
+    vlog("  [cfm_total] %.1f ms\n", prof_cfm_ms);
 
     // 8) Slice mel = z[:, mel_len1:] -> shape (80, T_mu - mel_len1).
     //
@@ -2970,7 +2972,8 @@ int s3gen_synthesize_to_wav(
     t0 = now_ms();
     auto wav = run_hift_decode(m_hift, mel, T_mel, s_stft, T_stft);
     vlog("  [hift_decode] %.1f ms\n", now_ms() - t0);
-    vlog("  [hift_total] %.1f ms\n", now_ms() - hift_t0);
+    double prof_hift_ms = now_ms() - hift_t0;
+    vlog("  [hift_total] %.1f ms\n", prof_hift_ms);
     vlog("  wav: %zu samples (%.3fs @ %d Hz)\n", wav.size(), (float)wav.size() / sr, sr);
 
     // First-chunk / batch-mode: apply raised-cosine fade-in to mask HiFT's
@@ -2993,6 +2996,17 @@ int s3gen_synthesize_to_wav(
     double pipeline_total = now_ms() - pipeline_t0;
     double audio_ms = 1000.0 * wav.size() / sr;
     fprintf(stderr, "BENCH: S3GEN_INFER_MS=%.0f AUDIO_MS=%.0f\n", pipeline_total, audio_ms);
+    // Opt-in per-chunk streaming profile (CHATTERBOX_CHUNK_PROFILE=1).  One
+    // machine-parseable line per S3Gen call exposing how the encoder + CFM
+    // cost scales with the input token window (n_total) vs the bounded HiFT
+    // stage — used to measure streaming TTFT / inter-chunk-latency growth.
+    if (const char * pf = getenv("CHATTERBOX_CHUNK_PROFILE"); pf && pf[0] && pf[0] != '0') {
+        fprintf(stderr,
+                "CHUNK_PROFILE n_total=%d T_mu=%d T_mel=%d enc_ms=%.1f cfm_ms=%.1f "
+                "hift_ms=%.1f pipeline_ms=%.1f audio_ms=%.0f\n",
+                n_total, T_mu, T_mel, prof_encoder_ms, prof_cfm_ms, prof_hift_ms,
+                pipeline_total, audio_ms);
+    }
     vlog("\n=== pipeline: %.1f ms for %.1f ms of audio (RTF=%.2f, %.1fx %s) ===\n",
          pipeline_total, audio_ms,
          pipeline_total / audio_ms,

--- a/tts-cpp/src/text_preprocess.cpp
+++ b/tts-cpp/src/text_preprocess.cpp
@@ -1,5 +1,8 @@
 #include "text_preprocess.h"
 
+#include <algorithm>
+#include <cctype>
+#include <cmath>
 #include <fstream>
 #include <mutex>
 #include <sstream>
@@ -10,6 +13,112 @@
 #endif
 
 namespace tts_cpp::chatterbox::text_preprocess {
+
+std::vector<std::string> split_text_for_tts(const std::string & text, int max_chars) {
+    std::vector<std::string> out;
+    if (text.empty() || max_chars <= 0) { out.push_back(text); return out; }
+
+    auto is_ws = [](unsigned char c) { return std::isspace(c) != 0; };
+
+    // Pass 1: sentence split.
+    std::vector<std::string> sentences;
+    {
+        std::string cur;
+        size_t i = 0;
+        while (i < text.size()) {
+            cur += text[i];
+            const char c = text[i];
+            const bool at_end = (i + 1 == text.size());
+            const bool nx_ws  = !at_end && is_ws((unsigned char)text[i + 1]);
+            if ((c == '.' || c == '?' || c == '!') && (at_end || nx_ws)) {
+                size_t j = i + 1;
+                while (j < text.size() && is_ws((unsigned char)text[j])) { cur += text[j]; ++j; }
+                sentences.push_back(cur);
+                cur.clear();
+                i = j;
+            } else {
+                ++i;
+            }
+        }
+        if (!cur.empty()) sentences.push_back(cur);
+    }
+
+    // Pass 2: refine any sentence longer than max_chars.
+    std::vector<std::string> refined;
+    refined.reserve(sentences.size());
+    for (auto & s : sentences) {
+        if ((int)s.size() <= max_chars) { refined.push_back(std::move(s)); continue; }
+        std::string acc;
+        size_t k = 0;
+        while (k < s.size()) {
+            acc += s[k];
+            const char c = s[k];
+            const bool nx_ws = (k + 1 < s.size()) && is_ws((unsigned char)s[k + 1]);
+            const bool soft_break = (c == ',' || c == ':' || c == ';') && nx_ws &&
+                                    (int)acc.size() > max_chars / 2;
+            if (soft_break) {
+                size_t j = k + 1;
+                while (j < s.size() && is_ws((unsigned char)s[j])) { acc += s[j]; ++j; }
+                refined.push_back(acc);
+                acc.clear();
+                k = j;
+                continue;
+            }
+            if ((int)acc.size() >= max_chars) {
+                // Last-resort hard break at a space if we can find one in the
+                // tail quarter; otherwise just cut.
+                size_t back = acc.size();
+                while (back > (size_t)(max_chars * 3 / 4) && !is_ws((unsigned char)acc[back - 1])) --back;
+                if (back <= (size_t)(max_chars / 2)) back = acc.size();
+                refined.push_back(acc.substr(0, back));
+                acc.erase(0, back);
+            }
+            ++k;
+        }
+        if (!acc.empty()) refined.push_back(acc);
+    }
+
+    // Pass 3: greedy forward merge of short fragments.
+    for (auto & s : refined) {
+        if (!out.empty() && (int)(out.back().size() + s.size()) <= max_chars) {
+            out.back() += s;
+        } else {
+            out.push_back(std::move(s));
+        }
+    }
+
+    // Strip trailing whitespace per segment.
+    for (auto & s : out) {
+        while (!s.empty() && is_ws((unsigned char)s.back())) s.pop_back();
+    }
+    // Drop empty segments (paranoia).
+    out.erase(std::remove_if(out.begin(), out.end(),
+                             [](const std::string & s) { return s.empty(); }),
+              out.end());
+    if (out.empty()) out.push_back(text);
+    return out;
+}
+
+void append_pcm_crossfade(std::vector<float> & dst, const std::vector<float> & src,
+                          int sr, int fade_ms) {
+    if (src.empty()) return;
+    if (dst.empty() || fade_ms <= 0) {
+        dst.insert(dst.end(), src.begin(), src.end());
+        return;
+    }
+    int fade_n = sr * fade_ms / 1000;
+    fade_n = std::min(fade_n, (int)dst.size());
+    fade_n = std::min(fade_n, (int)src.size());
+    if (fade_n <= 0) { dst.insert(dst.end(), src.begin(), src.end()); return; }
+
+    const size_t ofs = dst.size() - fade_n;
+    for (int i = 0; i < fade_n; ++i) {
+        const float t = (float)(i + 1) / (float)(fade_n + 1);
+        const float w = 0.5f * (1.0f - std::cos((float)M_PI * t));  // 0 → 1 cosine ramp
+        dst[ofs + i] = dst[ofs + i] * (1.0f - w) + src[i] * w;
+    }
+    dst.insert(dst.end(), src.begin() + fade_n, src.end());
+}
 
 namespace {
 

--- a/tts-cpp/src/text_preprocess.h
+++ b/tts-cpp/src/text_preprocess.h
@@ -16,6 +16,20 @@ std::string           encode_codepoint(uint32_t cp);
 std::string decompose_korean_to_jamo(const std::string & text);
 std::string convert_katakana_to_hiragana(const std::string & text);
 
+// Split `text` into TTS-friendly segments of at most `max_chars` bytes:
+// sentence-split on . ? !, soft-break over-long sentences at , : ;, then
+// greedily merge short fragments.  Byte-oriented (max_chars counts bytes,
+// not codepoints).  Returns {text} unchanged when text is empty or
+// max_chars <= 0.  Bounds T3 sequence length (prosody) and per-chunk
+// streaming cost; shared by the CLI and the Engine.
+std::vector<std::string> split_text_for_tts(const std::string & text, int max_chars);
+
+// Append `src` PCM onto `dst`, crossfading the trailing/leading `fade_ms`
+// via a raised-cosine ramp to remove clicks at segment seams.  Falls back to
+// a plain append when `dst` is empty or `fade_ms <= 0`.
+void append_pcm_crossfade(std::vector<float> & dst, const std::vector<float> & src,
+                          int sr, int fade_ms);
+
 class CangjieTable {
 public:
     CangjieTable() = default;

--- a/tts-cpp/test/test_chatterbox_engine_stream.cpp
+++ b/tts-cpp/test/test_chatterbox_engine_stream.cpp
@@ -1,0 +1,120 @@
+// Engine-level streaming-callback contract test for the per-sentence
+// segmentation path (Fix #2).  Exercises tts_cpp::chatterbox::Engine end to
+// end (no in-repo coverage existed before) and pins the invariants the
+// segmentation refactor must hold:
+//
+//   * chunk_index is a single monotonic 0..n-1 counter for the whole
+//     synthesize() call -- it does NOT reset per sentence segment;
+//   * is_last fires exactly once, on the very final chunk of the final
+//     segment;
+//   * result.pcm == concatenation of the callback chunk buffers
+//     (the documented invariant the streaming path must preserve);
+//   * result.audio_samples == result.pcm.size(); t3_tokens accumulates.
+//
+// Tested for both the single-segment path (auto-split off) and the
+// multi-segment path (auto-split on over a multi-sentence paragraph).
+//
+// Gated on the chatterbox T3 + S3Gen GGUFs (REQUIRES in CMakeLists), so it is
+// DISABLED in CI when those fixtures are absent.
+//
+// Usage: test-chatterbox-engine-stream T3.gguf S3GEN.gguf [language]
+
+#include "tts-cpp/chatterbox/engine.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using tts_cpp::chatterbox::Engine;
+using tts_cpp::chatterbox::EngineOptions;
+using tts_cpp::chatterbox::SynthesisResult;
+
+static int g_failures = 0;
+#define CHECK(cond, msg)                                                  \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            ++g_failures;                                                 \
+            std::fprintf(stderr, "FAIL: %s  (%s:%d)\n", msg, __FILE__, __LINE__); \
+        }                                                                 \
+    } while (0)
+
+// Synthesize `text` with streaming and assert the callback contract.
+// `expect_multi` requires at least 2 chunks (a stand-in for "multiple
+// segments emitted a stream of chunks").
+static void run_case(Engine & eng, const std::string & text,
+                     const char * label, bool expect_multi) {
+    std::vector<int> indices;
+    std::size_t total_samples = 0;
+    int is_last_count = 0;
+    int is_last_index = -1;
+
+    SynthesisResult res = eng.synthesize(
+        text, [&](const float * /*pcm*/, std::size_t n, int idx, bool is_last) {
+            indices.push_back(idx);
+            total_samples += n;
+            if (is_last) { ++is_last_count; is_last_index = idx; }
+        });
+
+    std::fprintf(stderr, "[%s] %zu chunks, %zu samples, t3_tokens=%d\n",
+                 label, indices.size(), (size_t)res.audio_samples, res.t3_tokens);
+
+    CHECK(!indices.empty(), "at least one chunk emitted");
+    if (expect_multi) CHECK(indices.size() >= 2, "multiple chunks emitted");
+
+    bool contiguous = true;
+    for (std::size_t k = 0; k < indices.size(); ++k)
+        if (indices[k] != (int)k) contiguous = false;
+    CHECK(contiguous, "chunk_index is contiguous 0..n-1 (monotonic, no per-segment reset)");
+
+    CHECK(is_last_count == 1, "is_last fires exactly once");
+    CHECK(is_last_index == (int)indices.size() - 1, "is_last only on the final chunk");
+
+    CHECK(res.pcm.size() == total_samples, "result.pcm == concat(callback chunks)");
+    CHECK(res.audio_samples == (int)res.pcm.size(), "audio_samples == result.pcm.size()");
+    CHECK(res.t3_tokens > 0, "t3_tokens accumulated > 0");
+    CHECK(res.t3_ms > 0.0 && res.s3gen_ms > 0.0, "t3_ms / s3gen_ms accumulated");
+}
+
+int main(int argc, char ** argv) {
+    if (argc < 3) {
+        std::fprintf(stderr, "usage: %s T3.gguf S3GEN.gguf [language]\n", argv[0]);
+        return 2;
+    }
+
+    EngineOptions base;
+    base.t3_gguf_path     = argv[1];
+    base.s3gen_gguf_path  = argv[2];
+    if (argc >= 4) base.language = argv[3];
+    base.seed             = 0;
+    base.n_threads        = 4;
+    base.stream_chunk_tokens = 25;
+
+    // Single-segment path: auto-split OFF (default).  One run_t3, one stream.
+    {
+        EngineOptions opts = base;
+        opts.max_sentence_chars = 0;
+        Engine eng(opts);
+        run_case(eng, "The quick brown fox jumps over the lazy dog.",
+                 "single-segment", /*expect_multi=*/false);
+    }
+
+    // Multi-segment path: auto-split ON over a 3-sentence paragraph.  Several
+    // segments, but ONE utterance: chunk_index stays monotonic across the
+    // segment boundaries and is_last fires only at the very end.
+    {
+        EngineOptions opts = base;
+        opts.max_sentence_chars = 30;
+        Engine eng(opts);
+        run_case(eng,
+                 "Hello there friend. The quick brown fox jumps over the lazy "
+                 "dog today. Good night and good luck everyone.",
+                 "multi-segment", /*expect_multi=*/true);
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_chatterbox_engine_stream: OK\n");
+        return 0;
+    }
+    std::fprintf(stderr, "test_chatterbox_engine_stream: %d failure(s)\n", g_failures);
+    return 1;
+}

--- a/tts-cpp/test/test_text_split.cpp
+++ b/tts-cpp/test/test_text_split.cpp
@@ -1,0 +1,96 @@
+// Unit test for tts_cpp::chatterbox::text_preprocess::split_text_for_tts.
+//
+// Pure text->text; needs no model or fixture, so it runs everywhere (CI
+// included).  Pins the byte-oriented sentence-splitter behaviour that both
+// the CLI (--max-sentence-chars) and the Engine (EngineOptions::
+// max_sentence_chars) rely on after the splitter was lifted into the shared
+// text_preprocess unit.
+
+#include "text_preprocess.h"
+
+#include <cstdio>
+#include <numeric>
+#include <string>
+#include <vector>
+
+using tts_cpp::chatterbox::text_preprocess::split_text_for_tts;
+
+static int g_failures = 0;
+#define CHECK(cond, msg)                                                  \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            ++g_failures;                                                 \
+            std::fprintf(stderr, "FAIL: %s  (%s:%d)\n", msg, __FILE__, __LINE__); \
+        }                                                                 \
+    } while (0)
+
+static std::string strip_spaces(const std::string & s) {
+    std::string out;
+    for (char c : s) if (c != ' ' && c != '\t' && c != '\n' && c != '\r') out += c;
+    return out;
+}
+
+int main() {
+    // 1) Empty text -> one (empty) segment.
+    {
+        auto segs = split_text_for_tts("", 180);
+        CHECK(segs.size() == 1, "empty text -> 1 segment");
+        CHECK(segs[0].empty(), "empty text -> empty segment");
+    }
+
+    // 2) max_chars <= 0 disables splitting: text returned unchanged.
+    {
+        const std::string t = "One. Two. Three.";
+        auto segs = split_text_for_tts(t, 0);
+        CHECK(segs.size() == 1, "max_chars=0 -> single segment");
+        CHECK(segs[0] == t, "max_chars=0 -> text unchanged");
+        auto segs2 = split_text_for_tts(t, -5);
+        CHECK(segs2.size() == 1 && segs2[0] == t, "max_chars<0 -> text unchanged");
+    }
+
+    // 3) Short text under max_chars -> a single segment (greedy merge keeps
+    //    short sentences together).
+    {
+        auto segs = split_text_for_tts("Hi there. How are you?", 200);
+        CHECK(segs.size() == 1, "short multi-sentence under max -> merged to 1");
+    }
+
+    // 4) Multi-sentence text with a small budget -> multiple segments, each
+    //    within budget and non-empty, content preserved (modulo whitespace).
+    {
+        const std::string t =
+            "The morning was cold and grey. The travellers gathered their "
+            "belongings slowly. They set out along the winding river path.";
+        const int max_chars = 40;
+        auto segs = split_text_for_tts(t, max_chars);
+        CHECK(segs.size() > 1, "long text with small budget -> splits");
+        for (const auto & s : segs) {
+            CHECK(!s.empty(), "no empty segment");
+            CHECK((int)s.size() <= max_chars, "segment within max_chars");
+        }
+        // Non-whitespace content is preserved across the split (the splitter
+        // only strips trailing whitespace per segment, never drops content).
+        std::string joined =
+            std::accumulate(segs.begin(), segs.end(), std::string{});
+        CHECK(strip_spaces(joined) == strip_spaces(t),
+              "split preserves non-whitespace content");
+    }
+
+    // 5) A single over-long run with no sentence terminators still gets
+    //    hard-broken to within budget (last-resort path).
+    {
+        std::string t(500, 'x');  // 500 chars, no spaces or terminators
+        const int max_chars = 60;
+        auto segs = split_text_for_tts(t, max_chars);
+        CHECK(segs.size() > 1, "over-long unbroken run -> hard-broken");
+        for (const auto & s : segs)
+            CHECK((int)s.size() <= max_chars, "hard-break within max_chars");
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_text_split: OK\n");
+        return 0;
+    }
+    std::fprintf(stderr, "test_text_split: %d failure(s)\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Problem

Chatterbox inference **streaming TTFT degrades as generation proceeds**. Diagnosed + measured root cause: the streaming loop feeds S3Gen the **cumulative** token prefix `[0, chunk_end)` on every chunk, so the conformer encoder + CFM flow-matching re-process *all* prior tokens each chunk — per-chunk cost grows with elapsed output (O(N²) over a segment). `skip_mel_frames` only trims the *output*, not the compute. Separately, `Engine::synthesize` decoded all of T3 up front (O(N²), gating first-audio on the whole utterance) with no per-sentence segmentation — the CLI had it, the Engine didn't.

Measured (Turbo, CPU, 20 chunks, single segment): per-chunk pipeline **2.8 s → 10.0 s**, RTF **3.2 → 12.6**.

## Changes

3 commits, all **opt-in** — defaults preserve exact legacy behaviour byte-for-byte, so no existing CLI/Engine caller or parity gate is affected:

1. **Per-chunk profiling** (`CHATTERBOX_CHUNK_PROFILE=1`) — env-gated, machine-parseable line (`n_total`, `T_mu`, encoder/CFM/HiFT ms) for measuring streaming cost. No-op when unset.
2. **Sliding-window S3Gen** (`--stream-left-context-tokens N` / `EngineOptions::stream_left_context_tokens`) — each chunk synthesizes only `[chunk_start − N, chunk_end)` (the new tokens plus `N` tokens of left context), with `skip_mel_frames` re-derived as `prev_mels_emitted − 2*win_start`. Per-chunk cost → O(1), total → O(N). `N = 0` (default) = exact legacy cumulative slice.
3. **Per-sentence Engine segmentation** (`EngineOptions::max_sentence_chars` + `crossfade_ms`) — `synthesize()` splits text into sentences and runs T3 + S3Gen per segment (HiFT / skip-mel state reset per sentence), bounding T3 cost and starting first-audio after sentence 1. `max_sentence_chars = 0` (default) = legacy single pass. Lifts `split_text_for_tts` + `append_pcm_crossfade` out of `chatterbox_cli.cpp` into the shared `text_preprocess` unit so the CLI and Engine share one copy. Callback contract pinned in `engine.h`: `chunk_index` monotonic across segments (no per-segment reset), `is_last` only on the final chunk of the final segment, `result.pcm == concat(callback chunks)`.

## Validation

- **Perf (Fix #1):** windowed (L=50) per-chunk pipeline flat ~3.8 s vs growing to 10 s — **2.88× last chunk, 1.67× total** (gap grows with length: O(N) vs O(N²)).
- **Quality:** streamed-vs-batch energy-envelope correlation **0.964 (windowed) ≈ 0.971 (legacy)** against the full-context batch ideal; same-seed L=0 vs L=50 = 0.975; identical output length; manual A/B listening confirmed.
- **Tests:** new `test-text-split` (pure splitter unit test — runs in CI) and `test-chatterbox-engine-stream` (Engine multi-segment streaming contract — gated on the Turbo GGUFs) both pass, asserting monotonic `chunk_index`, a single final `is_last`, `result.pcm == concat(callbacks)`, and accumulated stats. CLI auto-split regression passes.

## Caveats / follow-ups

- Not bit-exact vs the prior streaming output (CFM noise reseeds at the smaller `T_mu`). The formal `test-streaming` mel-RMS gate (needs the PyTorch reference dump + torch) should run in CI for numerical sign-off — it wasn't runnable in the dev sandbox.
- Validated on a **CPU-only** build; re-measure on Metal/Vulkan before relying on the absolute numbers.
- The synchronous per-sentence loop stalls ~1–2 s at each sentence boundary in *streaming* mode (no T3 prefetch). T3↔S3Gen pipelining — for absolute TTFT and to hide that stall — is a deferred follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
