### PR TITLE
QVAC-20616 [TTS GGML] Fix random tokens after inference (Chatterbox MTL end-of-speech)

### DIFF
--- a/tts-cpp/CMakeLists.txt
+++ b/tts-cpp/CMakeLists.txt
@@ -239,6 +239,7 @@ set(TTS_CPP_LIB_SOURCES
     src/campplus.cpp
     src/s3tokenizer.cpp
     src/t3_mtl.cpp
+    src/t3_stop_controller.cpp
     src/supertonic_gguf.cpp
     src/supertonic_preprocess.cpp
     src/supertonic_vocoder.cpp
@@ -591,6 +592,16 @@ if (TTS_CPP_BUILD_TESTS)
         LABEL    "fixture"
         ARGS     "${_tcb_s3gen_gguf}" "${_tcb_s3gen_ref}/wav_16k.npy" "${_tcb_s3gen_ref}/log_mel.npy" "${_tcb_s3gen_ref}/speech_tokens.npy"
         REQUIRES "${_tcb_s3gen_gguf}" "${_tcb_s3gen_ref}/wav_16k.npy" "${_tcb_s3gen_ref}/log_mel.npy" "${_tcb_s3gen_ref}/speech_tokens.npy")
+
+    # QVAC-20616: attention-free end-of-speech stop controller.  Pure host
+    # logic with no model / ggml dependency, so it links only its own source
+    # and always runs (no fixture REQUIRES).
+    add_executable(test-t3-stop-controller
+        test/test_t3_stop_controller.cpp
+        src/t3_stop_controller.cpp)
+    target_include_directories(test-t3-stop-controller PRIVATE src)
+    tts_cpp_apply_ccache(test-t3-stop-controller)
+    tts_cpp_register_test(test-t3-stop-controller LABEL "cpu")
 
     add_executable(test-mtl-tokenizer test/test_mtl_tokenizer.cpp)
     target_link_libraries(test-mtl-tokenizer PRIVATE tts-cpp)

--- a/tts-cpp/src/chatterbox_cli.cpp
+++ b/tts-cpp/src/chatterbox_cli.cpp
@@ -54,6 +54,7 @@
 #include "tts-cpp/chatterbox/s3gen_pipeline.h"
 #include "tts-cpp/supertonic/engine.h"
 #include "chatterbox_t3_internal.h"
+#include "t3_stop_controller.h"
 #include "t3_mtl.h"
 #include "npy.h"
 #include "voice_features.h"
@@ -2058,6 +2059,16 @@ int tts_cpp_cli_main(int argc, char ** argv) {
             constexpr int MAX_RETRIES = 3;
             auto rng_snapshot = rng;
 
+            // QVAC-20616: shared end-of-speech stop controller (same logic as
+            // chatterbox::Engine::run_t3).  Disabled for Turbo so that path is
+            // unchanged.  Params depend only on the (constant-across-retries)
+            // segment text length, so build once and reset per attempt.
+            const t3_stop_params stop_p = is_mtl
+                ? make_mtl_stop_params(model.hparams.stop_speech_token, sp_mtl.cfg_weight,
+                                       (int) seg_text_tokens[si].size(), params.n_predict)
+                : t3_stop_params{};
+            t3_stop_controller stop_ctrl;
+
             std::vector<int32_t> generated, best_generated;
             for (int attempt = 0; attempt <= MAX_RETRIES; ++attempt) {
                 rng = rng_snapshot;
@@ -2079,6 +2090,7 @@ int tts_cpp_cli_main(int argc, char ** argv) {
                 int n_past = prompt_len;
                 generated.clear();
                 generated.reserve(params.n_predict + 1);
+                stop_ctrl.reset(stop_p);
 
                 int32_t current = is_mtl
                     ? sample_next_token_mtl(logits_c, logits_u, generated, sp_mtl, rng,
@@ -2087,7 +2099,8 @@ int tts_cpp_cli_main(int argc, char ** argv) {
                 generated.push_back(current);
 
                 bool stopped_by_stop_token = false;
-                bool stopped_by_repetition  = false;
+                bool ctrl_forced_eos       = false;
+                t3_stop_reason ctrl_reason = t3_stop_reason::none;
                 for (int i = 0; i < params.n_predict; ++i) {
                     if (current == model.hparams.stop_speech_token) { stopped_by_stop_token = true; break; }
                     if (n_past + 1 > model.hparams.n_ctx) { fprintf(stderr, "KV cache full\n"); break; }
@@ -2100,44 +2113,43 @@ int tts_cpp_cli_main(int argc, char ** argv) {
                     }
                     if (!step_ok) throw std::runtime_error("step eval failed");
                     ++n_past;
-                    current = is_mtl
-                        ? sample_next_token_mtl(logits_c, logits_u, generated, sp_mtl, rng,
-                                                model.hparams.stop_speech_token)
-                        : sample_next_token(logits, generated, params, rng);
-                    generated.push_back(current);
 
-                    // Port of the token_repetition check in the Python
-                    // AlignmentStreamAnalyzer. MTL T3 sometimes emits a
-                    // plausible end-of-speech silence cadence mid-utterance
-                    // and then hallucinates more low-energy content before
-                    // eventually stopping. Two consecutive identical tokens
-                    // signal this cadence; gated to MTL because the Turbo
-                    // codebook has a different cadence signature and to a
-                    // 60-token minimum so we don't fire on the first
-                    // utterance of short multilingual inputs. We trim only
-                    // the trailing duplicate (resize(n-1)) and leave the
-                    // legitimate prior token; the downstream pop_back()
-                    // handles the stop-speech token.
-                    constexpr int kMtlMinTokensBeforeCadence = 60;
-                    if (is_mtl && generated.size() >= 2 &&
-                        (int)generated.size() > kMtlMinTokensBeforeCadence) {
-                        size_t n = generated.size();
-                        if (generated[n - 1] == generated[n - 2]) {
-                            generated.resize(n - 1);
-                            stopped_by_repetition = true;
-                            break;
-                        }
+                    // Force EOS when the model's own argmax has preferred the
+                    // stop token for several consecutive steps but sampling
+                    // kept missing it (the dominant "rambles after the text is
+                    // done" failure mode).  See src/t3_stop_controller.h.
+                    if (is_mtl && stop_ctrl.force_eos((int) generated.size(), logits_c, logits_u)) {
+                        current = model.hparams.stop_speech_token;
+                        ctrl_forced_eos = true;
+                    } else {
+                        current = is_mtl
+                            ? sample_next_token_mtl(logits_c, logits_u, generated, sp_mtl, rng,
+                                                    model.hparams.stop_speech_token)
+                            : sample_next_token(logits, generated, params, rng);
+                    }
+                    generated.push_back(current);
+                    if (current == model.hparams.stop_speech_token) { stopped_by_stop_token = true; break; }
+
+                    // Repetition cadence / budget backstop (MTL only).
+                    const t3_post_result pr = stop_ctrl.post_check(generated);
+                    if (pr.reason != t3_stop_reason::none) {
+                        if (pr.trim_tail > 0 && (int) generated.size() >= pr.trim_tail)
+                            generated.resize(generated.size() - (size_t) pr.trim_tail);
+                        ctrl_reason = pr.reason;
+                        break;
                     }
                 }
 
                 if (!generated.empty() && generated.back() == model.hparams.stop_speech_token)
                     generated.pop_back();
 
-                if (stopped_by_repetition && params.verbose) {
-                    fprintf(stderr, "  [t3 segment %zu/%zu] stopped on 2x repeated token (%d) "
-                                    "at %zu tokens; MTL end-of-speech cadence\n",
-                            si + 1, N_SEG, generated.empty() ? -1 : (int)generated.back(),
-                            generated.size());
+                if (params.verbose && (ctrl_forced_eos || ctrl_reason != t3_stop_reason::none)) {
+                    const char * why = ctrl_forced_eos                       ? "forced EOS (model argmax)"
+                                     : ctrl_reason == t3_stop_reason::repetition ? "repetition cadence"
+                                     : ctrl_reason == t3_stop_reason::budget     ? "token budget"
+                                     :                                             "?";
+                    fprintf(stderr, "  [t3 segment %zu/%zu] stop controller: %s at %zu tokens\n",
+                            si + 1, N_SEG, why, generated.size());
                 }
 
                 // Keep the longest attempt as the fallback in case every

--- a/tts-cpp/src/chatterbox_engine.cpp
+++ b/tts-cpp/src/chatterbox_engine.cpp
@@ -15,6 +15,7 @@
 #include "mtl_tokenizer.h"
 #include "npy.h"
 #include "t3_mtl.h"
+#include "t3_stop_controller.h"
 #include "tts-cpp/chatterbox/s3gen_pipeline.h"
 #include "voice_encoder.h"
 #include "voice_features.h"
@@ -495,6 +496,23 @@ struct Engine::Impl {
         std::vector<int32_t> generated;
         generated.reserve((size_t) opts.n_predict + 1);
 
+        // QVAC-20616: attention-free end-of-speech stop controller.  The MTL
+        // T3 often fails to emit stop_speech_token after it has finished the
+        // input text and rambles — a repeated near-silent cadence (audible as
+        // gutural / empty sounds) or fresh hallucinated content — until it
+        // hits n_predict (~40 s of audio).  The controller folds three
+        // signals into one place: (1) force EOS once the model's own argmax
+        // has preferred the stop token for several consecutive steps but
+        // sampling kept missing it, (2) detect a stuck repetition cadence,
+        // (3) a generous text-length-derived budget as a last-resort backstop.
+        // It is disabled for Turbo (default-constructed params) so that path
+        // is unchanged.  See src/t3_stop_controller.h.
+        t3_stop_controller stop_ctrl;
+        stop_ctrl.reset(is_mtl
+            ? make_mtl_stop_params(model.hparams.stop_speech_token, sp.cfg_weight,
+                                   (int) text_tokens.size(), opts.n_predict)
+            : t3_stop_params{});
+
         int32_t current = is_mtl
             ? sample_next_token_mtl(logits_c, logits_u, generated, sp, rng,
                                     model.hparams.stop_speech_token)
@@ -515,27 +533,23 @@ struct Engine::Impl {
                 throw std::runtime_error("Engine: T3 step eval failed");
             }
             ++n_past;
-            current = is_mtl
-                ? sample_next_token_mtl(logits_c, logits_u, generated, sp, rng,
-                                        model.hparams.stop_speech_token)
-                : sample_next_token_ex(logits, generated, sp, rng);
+            if (is_mtl && stop_ctrl.force_eos((int) generated.size(), logits_c, logits_u)) {
+                current = model.hparams.stop_speech_token;
+            } else {
+                current = is_mtl
+                    ? sample_next_token_mtl(logits_c, logits_u, generated, sp, rng,
+                                            model.hparams.stop_speech_token)
+                    : sample_next_token_ex(logits, generated, sp, rng);
+            }
             generated.push_back(current);
+            if (current == model.hparams.stop_speech_token) break;
 
-            // Port of AlignmentStreamAnalyzer's token_repetition guard
-            // (mirrors chatterbox_cli.cpp).  MTL T3 sometimes emits a
-            // plausible end-of-speech silence cadence mid-utterance and
-            // then hallucinates low-energy content (silence -> hissing
-            // -> garbage tokens) until n_predict, producing tens of
-            // seconds of trailing junk.  Three consecutive identical
-            // tokens cleanly signal the cadence without firing on normal
-            // speech; gated to MTL because Turbo's codebook has a
-            // different signature.
-            if (is_mtl && generated.size() >= 3) {
-                const size_t n = generated.size();
-                if (generated[n - 1] == generated[n - 2] &&
-                    generated[n - 2] == generated[n - 3]) {
-                    break;
+            const t3_post_result pr = stop_ctrl.post_check(generated);
+            if (pr.reason != t3_stop_reason::none) {
+                if (pr.trim_tail > 0 && (int) generated.size() >= pr.trim_tail) {
+                    generated.resize(generated.size() - (size_t) pr.trim_tail);
                 }
+                break;
             }
         }
 

--- a/tts-cpp/src/t3_stop_controller.cpp
+++ b/tts-cpp/src/t3_stop_controller.cpp
@@ -1,0 +1,216 @@
+#include "t3_stop_controller.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+namespace tts_cpp::chatterbox::detail {
+
+namespace {
+
+// --- small env-override helpers (calibration without a recompile) ----------
+
+bool env_present(const char * name) {
+    const char * v = std::getenv(name);
+    return v && v[0] != '\0';
+}
+
+// Treats unset / "" / "0" / "false" / "off" as "not disabled".
+bool env_truthy(const char * name) {
+    const char * v = std::getenv(name);
+    if (!v || v[0] == '\0') return false;
+    if (std::strcmp(v, "0") == 0) return false;
+    if (std::strcmp(v, "false") == 0 || std::strcmp(v, "FALSE") == 0) return false;
+    if (std::strcmp(v, "off") == 0 || std::strcmp(v, "OFF") == 0) return false;
+    return true;
+}
+
+int env_int(const char * name, int fallback) {
+    const char * v = std::getenv(name);
+    if (!v || v[0] == '\0') return fallback;
+    char * end = nullptr;
+    long parsed = std::strtol(v, &end, 10);
+    if (end == v) return fallback;
+    return (int) parsed;
+}
+
+float env_float(const char * name, float fallback) {
+    const char * v = std::getenv(name);
+    if (!v || v[0] == '\0') return fallback;
+    char * end = nullptr;
+    float parsed = std::strtof(v, &end);
+    if (end == v) return fallback;
+    return parsed;
+}
+
+// argmax of the CFG-combined logits.  combined[i] = cond[i] + w*(cond[i]-uncond[i]).
+// When `uncond` is empty (non-CFG callers), combined == cond.  Returns -1 for
+// an empty / size-mismatched input.
+int combined_argmax(const std::vector<float> & cond,
+                    const std::vector<float> & uncond,
+                    float                      cfg_weight) {
+    const size_t V = cond.size();
+    if (V == 0) return -1;
+    const bool use_cfg = (!uncond.empty() && uncond.size() == V && cfg_weight != 0.0f);
+
+    int   best_i = 0;
+    float best_v = -INFINITY;
+    for (size_t i = 0; i < V; ++i) {
+        float l = use_cfg ? cond[i] + cfg_weight * (cond[i] - uncond[i]) : cond[i];
+        if (l > best_v) { best_v = l; best_i = (int) i; }
+    }
+    return best_i;
+}
+
+// Softmax probability of `idx` over the CFG-combined logits.  Only called when
+// the probability gate is enabled.
+float combined_softmax_prob(const std::vector<float> & cond,
+                            const std::vector<float> & uncond,
+                            float                      cfg_weight,
+                            int                        idx) {
+    const size_t V = cond.size();
+    if (V == 0 || idx < 0 || (size_t) idx >= V) return 0.0f;
+    const bool use_cfg = (!uncond.empty() && uncond.size() == V && cfg_weight != 0.0f);
+
+    auto comb = [&](size_t i) -> float {
+        return use_cfg ? cond[i] + cfg_weight * (cond[i] - uncond[i]) : cond[i];
+    };
+
+    float maxl = -INFINITY;
+    for (size_t i = 0; i < V; ++i) maxl = std::max(maxl, comb(i));
+    if (!std::isfinite(maxl)) return 0.0f;
+
+    double sum = 0.0;
+    for (size_t i = 0; i < V; ++i) sum += std::exp((double) (comb(i) - maxl));
+    if (sum <= 0.0) return 0.0f;
+    return (float) (std::exp((double) (comb((size_t) idx) - maxl)) / sum);
+}
+
+} // namespace
+
+void t3_stop_controller::reset(const t3_stop_params & p) {
+    params_     = p;
+    eos_streak_ = 0;
+}
+
+bool t3_stop_controller::force_eos(int                        n_generated,
+                                   const std::vector<float> & logits_cond,
+                                   const std::vector<float> & logits_uncond) {
+    if (!params_.enabled || params_.eos_argmax_streak <= 0) {
+        eos_streak_ = 0;
+        return false;
+    }
+
+    const int argmax = combined_argmax(logits_cond, logits_uncond, params_.cfg_weight);
+    if (argmax == params_.stop_token) {
+        ++eos_streak_;
+    } else {
+        eos_streak_ = 0;
+        return false;
+    }
+
+    if (n_generated < params_.min_tokens) return false;
+    if (eos_streak_ < params_.eos_argmax_streak) return false;
+
+    if (params_.eos_prob_threshold > 0.0f) {
+        const float p = combined_softmax_prob(logits_cond, logits_uncond,
+                                               params_.cfg_weight, params_.stop_token);
+        if (p < params_.eos_prob_threshold) return false;
+    }
+
+    return true;
+}
+
+t3_post_result t3_stop_controller::post_check(const std::vector<int32_t> & generated) const {
+    t3_post_result result;
+    if (!params_.enabled) return result;
+
+    const int n = (int) generated.size();
+    if (n < params_.min_tokens) return result;
+
+    // 1. Repetition: smallest period first so a period-1 stutter (the common
+    //    near-silent cadence) is caught and reported as period 1.
+    if (params_.rep_repeats > 1 && params_.rep_max_period >= 1) {
+        const int max_p = std::min(params_.rep_max_period, n / params_.rep_repeats);
+        for (int p = 1; p <= max_p; ++p) {
+            // Are the last (rep_repeats * p) tokens `rep_repeats` copies of the
+            // trailing p-token block?
+            bool periodic = true;
+            const int span = params_.rep_repeats * p;
+            for (int k = 0; k < span; ++k) {
+                if (generated[n - 1 - k] != generated[n - 1 - (k % p)]) {
+                    periodic = false;
+                    break;
+                }
+            }
+            if (!periodic) continue;
+
+            // Extend the run backwards to count every trailing period, then
+            // trim all but one copy so the stutter collapses cleanly.
+            int periods = params_.rep_repeats;
+            while ((periods + 1) * p <= n) {
+                bool ok = true;
+                for (int k = periods * p; k < (periods + 1) * p; ++k) {
+                    if (generated[n - 1 - k] != generated[n - 1 - (k % p)]) {
+                        ok = false;
+                        break;
+                    }
+                }
+                if (!ok) break;
+                ++periods;
+            }
+            result.reason    = t3_stop_reason::repetition;
+            result.trim_tail = (periods - 1) * p;
+            return result;
+        }
+    }
+
+    // 2. Budget backstop.
+    if (params_.max_tokens > 0 && n >= params_.max_tokens) {
+        result.reason = t3_stop_reason::budget;
+        return result;
+    }
+
+    return result;
+}
+
+t3_stop_params make_mtl_stop_params(int32_t stop_token,
+                                    float   cfg_weight,
+                                    int     n_text_tokens,
+                                    int     n_predict_cap) {
+    t3_stop_params p;
+    p.enabled    = true;
+    p.stop_token = stop_token;
+    p.cfg_weight = cfg_weight;
+
+    // Skip the speech onset before any heuristic may fire.
+    p.min_tokens = std::max(0, env_int("CHATTERBOX_STOP_MIN_TOKENS", 16));
+
+    // Proportional budget: generous multiple of the text length so genuinely
+    // long inputs are never clipped, with an absolute floor for very short
+    // inputs and an absolute ceiling at the caller's n_predict.  Real MTL
+    // speech runs ~5-8 tokens per text token; 20x leaves a wide safety margin
+    // while still bounding a total EOS failure to a few seconds.
+    constexpr int   kBudgetFloor = 96;
+    const float ratio = std::max(0.0f, env_float("CHATTERBOX_STOP_MAX_RATIO", 20.0f));
+    int budget = (int) std::lround((double) ratio * (double) std::max(0, n_text_tokens))
+                 + 64;
+    budget = std::max(budget, kBudgetFloor);
+    if (n_predict_cap > 0) budget = std::min(budget, n_predict_cap);
+    budget = env_int("CHATTERBOX_STOP_MAX_TOKENS", budget);
+    p.max_tokens = budget;
+
+    p.rep_max_period    = std::max(0, env_int("CHATTERBOX_STOP_REP_PERIOD", 8));
+    p.rep_repeats       = std::max(0, env_int("CHATTERBOX_STOP_REP_REPEATS", 3));
+    p.eos_argmax_streak = env_int("CHATTERBOX_STOP_EOS_STREAK", 2);
+    p.eos_prob_threshold = std::max(0.0f, env_float("CHATTERBOX_STOP_EOS_PROB", 0.0f));
+
+    if (env_present("CHATTERBOX_STOP_DISABLE") && env_truthy("CHATTERBOX_STOP_DISABLE")) {
+        p.enabled = false;
+    }
+    return p;
+}
+
+} // namespace tts_cpp::chatterbox::detail

--- a/tts-cpp/src/t3_stop_controller.h
+++ b/tts-cpp/src/t3_stop_controller.h
@@ -1,0 +1,150 @@
+#pragma once
+
+// Robust end-of-speech stop controller for the Chatterbox T3 autoregressive
+// decode loop (QVAC-20616).
+//
+// Background
+// ----------
+// The T3 decoder emits speech tokens one at a time until it samples the
+// `stop_speech_token` or hits the `n_predict` cap (default 1000 ≈ 40 s of
+// audio at ~25 tok/s).  On the multilingual (MTL) variant the model
+// frequently fails to emit a stop token after it has finished speaking the
+// input text and instead "rambles" — either repeating a near-silent cadence
+// (audible as gutural/empty sounds) or hallucinating fresh low-energy content
+// for many seconds.  The Python reference (resemble-ai/chatterbox) suppresses
+// this with an attention-based `AlignmentStreamAnalyzer` that force-emits EOS.
+//
+// This controller is the host-side, attention-free half of the fix.  It is
+// intentionally free of any ggml / model dependency so it can be unit-tested
+// in isolation (see test/test_t3_stop_controller.cpp).  It folds three
+// complementary signals into one place so the engine and CLI decode loops
+// behave identically (previously the engine used a 3×-identical-token break
+// with no floor while the CLI used a 2×-identical-token break with a 60-token
+// floor):
+//
+//   1. EOS confidence — if the model's own (CFG-combined) argmax is the stop
+//      token for `eos_argmax_streak` consecutive steps, the model wants to
+//      stop but temperature/top-p sampling keeps missing it.  We force the
+//      stop.  This is a safe signal: it never fires unless the model itself
+//      prefers EOS.
+//   2. Repetition — a token cycle of period p∈[1, rep_max_period] repeated
+//      `rep_repeats`+ times is the stuck near-silent cadence; we stop and trim
+//      the duplicated tail.
+//   3. Budget — a generous, text-length-derived hard cap so a total EOS
+//      failure is bounded to a few seconds instead of ~40 s.
+//
+// All of these only fire after a `min_tokens` floor so the initial speech
+// onset (and the reference's known early-cutoff failure mode) is protected.
+
+#include <cstdint>
+#include <vector>
+
+namespace tts_cpp::chatterbox::detail {
+
+struct t3_stop_params {
+    // Master gate.  Left false by default so the Turbo (English GPT-2) path —
+    // which does not exhibit this bug — keeps its existing behaviour untouched
+    // when a default-constructed param block is used.
+    bool    enabled            = false;
+
+    // Vocabulary id of the end-of-speech token (hparams.stop_speech_token).
+    int32_t stop_token         = 0;
+
+    // CFG mixing weight used to reconstruct the logits the sampler actually
+    // ranks: combined = cond + cfg_weight * (cond - uncond).  Pass an empty
+    // uncond vector to treat it as a plain (non-CFG) logits vector.
+    float   cfg_weight         = 0.0f;
+
+    // No heuristic stop may fire before this many speech tokens have been
+    // generated.  Protects the speech onset and avoids the reference's
+    // early-cutoff regression.
+    int     min_tokens         = 16;
+
+    // Hard upper bound on generated speech tokens (the last-resort backstop).
+    // 0 disables the budget check (the caller's own n_predict still applies).
+    int     max_tokens         = 0;
+
+    // Repetition: a cycle of period in [1, rep_max_period] repeated at least
+    // rep_repeats times triggers a stop.  rep_repeats <= 1 or rep_max_period
+    // < 1 disables the check.
+    int     rep_max_period     = 8;
+    int     rep_repeats        = 3;
+
+    // EOS confidence: force a stop once the CFG-combined argmax has been the
+    // stop token for this many consecutive steps.  <= 0 disables the check.
+    int     eos_argmax_streak  = 2;
+
+    // Optional extra gate on EOS confidence: also require the stop token's
+    // softmax probability to be >= this value.  0 disables the probability
+    // gate (argmax + streak alone decide).
+    float   eos_prob_threshold = 0.0f;
+};
+
+enum class t3_stop_reason {
+    none = 0,
+    eos_confidence, // model's argmax is EOS but sampling kept missing it
+    repetition,     // periodic token cycle (stuck cadence)
+    budget,         // hit the max_tokens safety net
+};
+
+struct t3_post_result {
+    t3_stop_reason reason    = t3_stop_reason::none;
+    // Number of tokens to drop from the tail of `generated` before
+    // finalisation (used to strip a repeated cadence down to a single
+    // period).  Always 0 unless reason == repetition.
+    int            trim_tail = 0;
+};
+
+// Stateless-per-construction controller; `reset` (re)initialises it for one
+// decode (one segment / one synthesize call).
+class t3_stop_controller {
+public:
+    void reset(const t3_stop_params & p);
+
+    const t3_stop_params & params() const { return params_; }
+
+    // Pre-sampling hook.  Call with the per-step logits the sampler is about
+    // to rank (cond + optional uncond) and the number of tokens generated so
+    // far.  Returns true when the model's own preference is to stop and the
+    // caller should emit `stop_token` instead of sampling.
+    //
+    // Updates the internal EOS-argmax streak as a side effect, so it must be
+    // called exactly once per decode step even when the result is ignored.
+    bool force_eos(int                        n_generated,
+                   const std::vector<float> & logits_cond,
+                   const std::vector<float> & logits_uncond);
+
+    // Post-sampling hook.  Call with the full generated token vector (after
+    // pushing the freshly sampled token).  Detects a stuck repetition cadence
+    // or a blown budget and reports how much of the tail to trim.
+    t3_post_result post_check(const std::vector<int32_t> & generated) const;
+
+private:
+    t3_stop_params params_;
+    int            eos_streak_ = 0;
+};
+
+// Build a calibrated parameter block for the multilingual (MTL) variant.
+//
+//   stop_token     : hparams.stop_speech_token
+//   cfg_weight     : sampling cfg_weight (for logit reconstruction)
+//   n_text_tokens  : number of input text tokens for this segment (drives the
+//                    proportional budget so long inputs are never clipped)
+//   n_predict_cap  : the caller's hard n_predict (the budget never exceeds it)
+//
+// Reads optional environment overrides so the thresholds can be tuned on a
+// device without recompiling:
+//   CHATTERBOX_STOP_DISABLE      (any non-empty/non-"0" => disable entirely)
+//   CHATTERBOX_STOP_MIN_TOKENS   (int)
+//   CHATTERBOX_STOP_MAX_TOKENS   (int; overrides the computed budget)
+//   CHATTERBOX_STOP_MAX_RATIO    (float; tokens-per-text-token budget ratio)
+//   CHATTERBOX_STOP_EOS_STREAK   (int)
+//   CHATTERBOX_STOP_EOS_PROB     (float)
+//   CHATTERBOX_STOP_REP_PERIOD   (int; max repetition period)
+//   CHATTERBOX_STOP_REP_REPEATS  (int)
+t3_stop_params make_mtl_stop_params(int32_t stop_token,
+                                    float   cfg_weight,
+                                    int     n_text_tokens,
+                                    int     n_predict_cap);
+
+} // namespace tts_cpp::chatterbox::detail

--- a/tts-cpp/test/test_t3_stop_controller.cpp
+++ b/tts-cpp/test/test_t3_stop_controller.cpp
@@ -1,0 +1,294 @@
+// Unit tests for the attention-free T3 end-of-speech stop controller
+// (QVAC-20616).  Pure host logic — no model or ggml dependency — so it builds
+// and runs standalone:
+//
+//   g++ -std=c++17 -I src test/test_t3_stop_controller.cpp src/t3_stop_controller.cpp -o /tmp/t && /tmp/t
+//
+// Coverage:
+//   - EOS-confidence: argmax streak forces a stop, respects the min-token
+//     floor, resets on a non-EOS argmax, honours CFG combination and the
+//     optional probability gate.
+//   - Repetition: period-1/2/3 cadences are detected with the correct
+//     trim_tail, the min-token floor is respected, and non-repeating tails are
+//     left alone.
+//   - Budget: fires exactly at max_tokens.
+//   - Disabled params (the Turbo path) preserve the old behaviour: no forced
+//     EOS, no post-check stop.
+//   - make_mtl_stop_params budget scaling + env overrides.
+
+#include "t3_stop_controller.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+using namespace tts_cpp::chatterbox::detail;
+
+namespace {
+
+int g_failures = 0;
+int g_checks   = 0;
+
+#define CHECK(cond, ...) do {                                            \
+    ++g_checks;                                                          \
+    if (!(cond)) {                                                       \
+        ++g_failures;                                                    \
+        fprintf(stderr, "FAIL %s:%d  ", __FILE__, __LINE__);             \
+        fprintf(stderr, __VA_ARGS__);                                    \
+        fprintf(stderr, "\n");                                           \
+    }                                                                    \
+} while (0)
+
+constexpr int     V   = 16;
+constexpr int32_t EOS = 9;
+
+// Logits whose argmax is `argmax_idx` (that entry = 5.0, the rest = 0.0).
+std::vector<float> logits_with_argmax(int argmax_idx) {
+    std::vector<float> l(V, 0.0f);
+    if (argmax_idx >= 0 && argmax_idx < V) l[argmax_idx] = 5.0f;
+    return l;
+}
+
+t3_stop_params base_params() {
+    t3_stop_params p;
+    p.enabled            = true;
+    p.stop_token         = EOS;
+    p.cfg_weight         = 0.0f;
+    p.min_tokens         = 4;
+    p.max_tokens         = 0;      // disable budget unless a test sets it
+    p.rep_max_period     = 8;
+    p.rep_repeats        = 3;
+    p.eos_argmax_streak  = 2;
+    p.eos_prob_threshold = 0.0f;
+    return p;
+}
+
+void test_eos_confidence_streak() {
+    t3_stop_controller c;
+    c.reset(base_params());
+
+    const std::vector<float> empty;
+    const auto eos_logits   = logits_with_argmax(EOS);
+    const auto other_logits = logits_with_argmax(3);
+
+    // Past the floor, a single EOS-argmax step is not enough (streak == 2).
+    CHECK(!c.force_eos(10, eos_logits, empty), "streak 1 should not force");
+    // Second consecutive EOS-argmax step forces the stop.
+    CHECK(c.force_eos(10, eos_logits, empty), "streak 2 should force");
+
+    // A non-EOS argmax resets the streak.
+    CHECK(!c.force_eos(10, other_logits, empty), "non-EOS resets streak");
+    CHECK(!c.force_eos(10, eos_logits, empty), "streak rebuilds from 1");
+    CHECK(c.force_eos(10, eos_logits, empty), "streak 2 forces again");
+}
+
+void test_eos_confidence_min_tokens_floor() {
+    t3_stop_controller c;
+    c.reset(base_params());                 // min_tokens = 4
+
+    const std::vector<float> empty;
+    const auto eos_logits = logits_with_argmax(EOS);
+
+    // Streak builds even below the floor, but must not force before it.
+    CHECK(!c.force_eos(1, eos_logits, empty), "below floor: no force (1)");
+    CHECK(!c.force_eos(2, eos_logits, empty), "below floor: no force (2)");
+    CHECK(!c.force_eos(3, eos_logits, empty), "below floor: no force (3)");
+    // n_generated now >= floor and streak >= 2 -> force.
+    CHECK(c.force_eos(4, eos_logits, empty), "at floor: force");
+}
+
+void test_eos_confidence_cfg() {
+    // With CFG, combined = cond + w*(cond - uncond).  Choose cond/uncond so the
+    // raw cond argmax is NOT EOS but the CFG-combined argmax IS.
+    t3_stop_params p = base_params();
+    p.cfg_weight       = 2.0f;
+    p.eos_argmax_streak = 1;                 // single step for a focused check
+
+    t3_stop_controller c;
+    c.reset(p);
+
+    std::vector<float> cond(V, 0.0f);
+    std::vector<float> uncond(V, 0.0f);
+    // cond: token 3 highest (3.0), EOS at 2.0.
+    cond[3] = 3.0f;
+    cond[EOS] = 2.0f;
+    // uncond: strongly favours token 3 so CFG suppresses it.
+    uncond[3] = 5.0f;
+    uncond[EOS] = 0.0f;
+    // combined[3]  = 3 + 2*(3-5)  = -1
+    // combined[EOS]= 2 + 2*(2-0)  =  6  -> argmax is EOS
+    CHECK(c.force_eos(10, cond, uncond), "CFG-combined argmax should be EOS");
+
+    // Without CFG (cfg_weight ignored via empty uncond path) the raw argmax is
+    // token 3, so no force.
+    t3_stop_controller c2;
+    c2.reset(p);
+    CHECK(!c2.force_eos(10, cond, std::vector<float>{}), "raw cond argmax is not EOS");
+}
+
+void test_eos_prob_gate() {
+    t3_stop_params p = base_params();
+    p.eos_argmax_streak  = 1;
+    p.eos_prob_threshold = 0.99f;            // demanding
+
+    const std::vector<float> empty;
+
+    // Flat-ish logits: EOS is argmax but only marginally, prob well under 0.99.
+    std::vector<float> weak(V, 1.0f);
+    weak[EOS] = 1.2f;
+    t3_stop_controller c;
+    c.reset(p);
+    CHECK(!c.force_eos(10, weak, empty), "weak EOS prob should not pass gate");
+
+    // Dominant EOS: prob ~1.0, passes the gate.
+    std::vector<float> strong(V, 0.0f);
+    strong[EOS] = 50.0f;
+    t3_stop_controller c2;
+    c2.reset(p);
+    CHECK(c2.force_eos(10, strong, empty), "dominant EOS prob passes gate");
+}
+
+void test_repetition_period1() {
+    t3_stop_controller c;
+    c.reset(base_params());                  // rep_repeats = 3, min_tokens = 4
+
+    // 5 distinct tokens then the value 7 four times in a row.
+    std::vector<int32_t> g = {1, 2, 3, 4, 7, 7, 7, 7};
+    t3_post_result r = c.post_check(g);
+    CHECK(r.reason == t3_stop_reason::repetition, "period-1 repetition detected");
+    // 4 copies of a period-1 block -> trim 3, leaving one 7.
+    CHECK(r.trim_tail == 3, "period-1 trim_tail == 3, got %d", r.trim_tail);
+}
+
+void test_repetition_period2() {
+    t3_stop_controller c;
+    c.reset(base_params());
+
+    // "5 6" repeated 3 times at the tail.
+    std::vector<int32_t> g = {1, 2, 3, 4, 5, 6, 5, 6, 5, 6};
+    t3_post_result r = c.post_check(g);
+    CHECK(r.reason == t3_stop_reason::repetition, "period-2 repetition detected");
+    // 3 copies of a 2-token block -> trim (3-1)*2 = 4.
+    CHECK(r.trim_tail == 4, "period-2 trim_tail == 4, got %d", r.trim_tail);
+}
+
+void test_repetition_below_floor() {
+    t3_stop_params p = base_params();
+    p.min_tokens = 100;                      // floor above the input length
+    t3_stop_controller c;
+    c.reset(p);
+
+    std::vector<int32_t> g = {7, 7, 7, 7, 7, 7};
+    t3_post_result r = c.post_check(g);
+    CHECK(r.reason == t3_stop_reason::none, "no repetition stop below min_tokens");
+}
+
+void test_no_false_repetition() {
+    t3_stop_controller c;
+    c.reset(base_params());
+
+    // Strictly increasing tail — no cycle.
+    std::vector<int32_t> g = {1, 2, 3, 4, 5, 6, 7, 8};
+    t3_post_result r = c.post_check(g);
+    CHECK(r.reason == t3_stop_reason::none, "non-repeating tail not flagged");
+
+    // A single duplicated pair is below rep_repeats=3.
+    std::vector<int32_t> g2 = {1, 2, 3, 4, 5, 9, 9};
+    t3_post_result r2 = c.post_check(g2);
+    CHECK(r2.reason == t3_stop_reason::none, "two identical not enough (need 3)");
+}
+
+void test_budget() {
+    t3_stop_params p = base_params();
+    p.rep_repeats = 0;                       // isolate the budget check
+    p.max_tokens  = 6;
+    t3_stop_controller c;
+    c.reset(p);
+
+    std::vector<int32_t> five = {1, 2, 3, 4, 5};
+    CHECK(c.post_check(five).reason == t3_stop_reason::none, "under budget: no stop");
+
+    std::vector<int32_t> six = {1, 2, 3, 4, 5, 6};
+    t3_post_result r = c.post_check(six);
+    CHECK(r.reason == t3_stop_reason::budget, "at budget: stop");
+    CHECK(r.trim_tail == 0, "budget never trims");
+}
+
+void test_disabled_preserves_turbo() {
+    t3_stop_params p;                        // default: enabled == false
+    t3_stop_controller c;
+    c.reset(p);
+
+    const auto eos_logits = logits_with_argmax(0);   // argmax == stop_token (0)
+    CHECK(!c.force_eos(1000, eos_logits, std::vector<float>{}),
+          "disabled controller never forces EOS");
+
+    std::vector<int32_t> g = {0, 0, 0, 0, 0, 0, 0, 0};
+    CHECK(c.post_check(g).reason == t3_stop_reason::none,
+          "disabled controller never stops on repetition/budget");
+}
+
+void test_make_mtl_params_budget_scaling() {
+    // Short input: budget hits the absolute floor (96).
+    {
+        t3_stop_params p = make_mtl_stop_params(EOS, 0.5f, /*n_text=*/1, /*cap=*/1000);
+        CHECK(p.enabled, "mtl params enabled");
+        CHECK(p.stop_token == EOS, "stop token propagated");
+        CHECK(p.max_tokens == 96, "short input -> budget floor 96, got %d", p.max_tokens);
+    }
+    // Medium input: 20*40 + 64 = 864, under the cap.
+    {
+        t3_stop_params p = make_mtl_stop_params(EOS, 0.0f, /*n_text=*/40, /*cap=*/1000);
+        CHECK(p.max_tokens == 864, "20*40+64 == 864, got %d", p.max_tokens);
+    }
+    // Long input: budget clamped to the n_predict cap.
+    {
+        t3_stop_params p = make_mtl_stop_params(EOS, 0.0f, /*n_text=*/200, /*cap=*/1000);
+        CHECK(p.max_tokens == 1000, "long input clamped to cap 1000, got %d", p.max_tokens);
+    }
+}
+
+void test_make_mtl_params_env_overrides() {
+    setenv("CHATTERBOX_STOP_MIN_TOKENS", "32", 1);
+    setenv("CHATTERBOX_STOP_MAX_TOKENS", "123", 1);
+    setenv("CHATTERBOX_STOP_EOS_STREAK", "5", 1);
+    setenv("CHATTERBOX_STOP_REP_REPEATS", "4", 1);
+    t3_stop_params p = make_mtl_stop_params(EOS, 0.0f, 40, 1000);
+    CHECK(p.min_tokens == 32, "env min_tokens override");
+    CHECK(p.max_tokens == 123, "env max_tokens override");
+    CHECK(p.eos_argmax_streak == 5, "env eos_streak override");
+    CHECK(p.rep_repeats == 4, "env rep_repeats override");
+
+    setenv("CHATTERBOX_STOP_DISABLE", "1", 1);
+    t3_stop_params p2 = make_mtl_stop_params(EOS, 0.0f, 40, 1000);
+    CHECK(!p2.enabled, "env disable override");
+
+    unsetenv("CHATTERBOX_STOP_MIN_TOKENS");
+    unsetenv("CHATTERBOX_STOP_MAX_TOKENS");
+    unsetenv("CHATTERBOX_STOP_EOS_STREAK");
+    unsetenv("CHATTERBOX_STOP_REP_REPEATS");
+    unsetenv("CHATTERBOX_STOP_DISABLE");
+}
+
+} // namespace
+
+int main() {
+    test_eos_confidence_streak();
+    test_eos_confidence_min_tokens_floor();
+    test_eos_confidence_cfg();
+    test_eos_prob_gate();
+    test_repetition_period1();
+    test_repetition_period2();
+    test_repetition_below_floor();
+    test_no_false_repetition();
+    test_budget();
+    test_disabled_preserves_turbo();
+    test_make_mtl_params_budget_scaling();
+    test_make_mtl_params_env_overrides();
+
+    fprintf(stderr, "\n%s: %d/%d checks passed\n",
+            g_failures == 0 ? "PASS" : "FAIL",
+            g_checks - g_failures, g_checks);
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
The Chatterbox **multilingual (MTL)** T3 frequently fails to emit `stop_speech_token` once the input text has been spoken and keeps generating — a repeated near-silent cadence (gutural/empty sounds) or fresh hallucinated content — until `n_predict` (default 1000 ≈ **~40s of audio**). This is the "says my text then talks for ~20 more seconds about random stuff" bug.

The previous mitigations were inconsistent per-loop heuristics (engine: 3×-identical-token, no floor; CLI: 2×-identical + 60-token floor) and only caught the *identical-token* cadence, not the varied "rambling" case.

This PR replaces them with one shared, attention-free **stop controller** (`src/t3_stop_controller.{h,cpp}`) used by both `chatterbox::Engine::run_t3` (the SDK/app path) and the CLI segment loop:

- **EOS confidence** — force a stop once the model's own CFG-combined argmax is the stop token for N consecutive steps but temperature/top-p sampling kept missing it (the dominant rambling mode).
- **Repetition** — detect a period-1..8 token cadence repeated ≥3× and trim the duplicated tail.
- **Budget** — a generous text-length-derived cap as a last-resort backstop.

All gated behind a `min_tokens` floor so speech onset is never clipped, and every threshold is overridable via `CHATTERBOX_STOP_*` env vars for on-device calibration. The **Turbo (English) path is unchanged** (controller disabled via default-constructed params).

## Validation
CPU run on the MTL GGUF with the issue's `reference_fr.wav` + "hello how are you" across 30 seeds:

| case | controller OFF | controller ON |
|---|---|---|
| seed 12 (ramble) | 453 tok / **18.2 s** | 33 tok / **1.4 s** |
| seed 1 (ramble) | 170 tok | 32 tok |
| seed 3 (normal) | 44 tok, speech ends 1.38s | 39 tok, **speech ends 1.38s** |

No clipping on healthy seeds: spoken-content end-time is identical off vs on — only trailing silence/cadence is trimmed.

## Test plan
- [x] `test-t3-stop-controller` (35 model-free unit checks) — `ctest -L cpu`
- [x] Full bundled-ggml build links (`libtts-cpp.a` + `tts-cli`)
- [x] E2E MTL synth: catastrophic rambles fixed, normal seeds unaffected
- [ ] Reviewer: spot-check on Metal/Vulkan/OpenCL device + the SDK `tts-ggml` addon
- [ ] A/B with `CHATTERBOX_STOP_DISABLE=1` to compare against current behaviour

## Follow-up (Phase 2)
Durable fix: port the reference `AlignmentStreamAnalyzer` by exposing one T3 attention head to drive alignment-based EOS (catches the remaining mild ~2.5–3s self-terminated over-runs this heuristic leaves).

Made with [Cursor](https://cursor.com)