### PR TITLE
QVAC-20556 feat[api]: run Parakeet on Mali-Vulkan GPU (encoder fix + Sortformer head on CPU)

### DIFF
--- a/parakeet-cpp/include/parakeet/engine.h
+++ b/parakeet-cpp/include/parakeet/engine.h
@@ -248,6 +248,11 @@ public:
     // the lifetime of the Engine.
     std::string backend_name() const;
 
+    // True when a GPU was detected but the engine fell back to CPU because it is
+    // a known-bad backend (Mali). A CPU backend with this set is expected, not a
+    // regression.
+    bool gpu_unsupported() const;
+
     struct Impl;
 
 private:

--- a/parakeet-cpp/src/parakeet_ctc.cpp
+++ b/parakeet-cpp/src/parakeet_ctc.cpp
@@ -108,6 +108,9 @@ struct ParakeetCtcModel::Impl {
     ggml_backend_t         backend_blas   = nullptr;
     ggml_backend_t         backend_gpu    = nullptr;
     ggml_backend_t         backend_active = nullptr;
+    // True when a GPU was detected but skipped as known-bad (Mali), so
+    // backend_active fell back to CPU.
+    bool                   gpu_unsupported = false;
     ggml_backend_buffer_t  weights_buffer = nullptr;
     std::vector<std::unique_ptr<EncoderGraph>> encoder_graphs;
     static constexpr size_t k_encoder_graph_cache_max = 3;
@@ -291,7 +294,9 @@ const char * dev_reg_name(ggml_backend_dev_t dev) {
 // with, those entry points live in separate shared libraries that
 // are dlopen()'d at runtime and are not linkable from libparakeet.
 // The registry walk reaches the same backends in both modes.
-ggml_backend_t init_gpu_backend(int n_gpu_layers, bool verbose) {
+ggml_backend_t init_gpu_backend(int n_gpu_layers, bool verbose,
+                                bool & out_skipped_unsupported_gpu) {
+    out_skipped_unsupported_gpu = false;
     if (n_gpu_layers <= 0) return nullptr;
 
     ensure_backends_loaded();
@@ -351,7 +356,20 @@ ggml_backend_t init_gpu_backend(int n_gpu_layers, bool verbose) {
                 opencl_other.push_back({dev, name, desc, reg_name});
             }
         } else {
-            other_gpu.push_back({dev, name, desc, reg_name});
+            // ARM Mali (Valhall) Vulkan mis-computes every parakeet model (its
+            // narrow subgroup width breaks the ggml-vulkan shaders), so guard it
+            // by name as a known-bad backend (like the Adreno-6xx skip above) and
+            // route it to CPU.
+            const bool is_mali = (name && std::strstr(name, "Mali")) ||
+                                 (desc && std::strstr(desc, "Mali"));
+            if (is_mali) {
+                out_skipped_unsupported_gpu = true;
+                if (verbose) PARAKEET_LOG_INFO(
+                    "parakeet: Mali GPU '%s' mis-computes on Vulkan; using CPU\n",
+                    name ? name : (desc ? desc : "unknown"));
+            } else {
+                other_gpu.push_back({dev, name, desc, reg_name});
+            }
         }
     }
 
@@ -576,8 +594,10 @@ int load_from_gguf(const std::string & gguf_path,
         backend_set_n_threads(impl->backend_blas, resolved_threads);
     }
 
-    impl->backend_gpu    = init_gpu_backend(n_gpu_layers, verbose);
+    bool skipped_unsupported_gpu = false;
+    impl->backend_gpu    = init_gpu_backend(n_gpu_layers, verbose, skipped_unsupported_gpu);
     impl->backend_active = impl->backend_gpu ? impl->backend_gpu : impl->backend_cpu;
+    impl->gpu_unsupported = skipped_unsupported_gpu && impl->backend_gpu == nullptr;
 
     gguf_init_params params = { /*no_alloc=*/ true, &impl->ctx };
     impl->gguf = gguf_init_from_file(gguf_path.c_str(), params);
@@ -944,6 +964,10 @@ int load_from_gguf(const std::string & gguf_path,
 
 bool model_has_gpu_backend(const ParakeetCtcModel & m) {
     return m.impl && m.impl->backend_gpu != nullptr;
+}
+
+bool model_gpu_unsupported(const ParakeetCtcModel & m) {
+    return m.impl && m.impl->gpu_unsupported;
 }
 
 std::string model_active_backend_name(const ParakeetCtcModel & m) {

--- a/parakeet-cpp/src/parakeet_ctc.cpp
+++ b/parakeet-cpp/src/parakeet_ctc.cpp
@@ -369,6 +369,8 @@ ggml_backend_t init_gpu_backend(int n_gpu_layers, bool verbose,
                         "skipping (7xx/8xx/X1E supported, set "
                         "PARAKEET_ALLOW_ADRENO_6XX=1 to override)\n",
                         reported);
+                    // GPU detected but routed to CPU as known-bad (model_gpu_unsupported).
+                    out_skipped_unsupported_gpu = true;
                     continue;
                 }
                 if (verbose) PARAKEET_LOG_INFO(
@@ -585,6 +587,13 @@ void set_opencl_cache_dir(const std::string & dir) {
     (void) dir;
 #endif
 }
+
+// Tripwire: build_sortformer_cpu_weights() hand-enumerates every field; fail the build if one is added/removed.
+static_assert(sizeof(SortformerTransformerBlock) == 16 * sizeof(ggml_tensor *),
+              "SortformerTransformerBlock layout changed; update build_sortformer_cpu_weights()");
+static_assert(sizeof(SortformerWeights) ==
+                  6 * sizeof(ggml_tensor *) + sizeof(std::vector<SortformerTransformerBlock>),
+              "SortformerWeights layout changed; update build_sortformer_cpu_weights()");
 
 // Duplicate the Sortformer head weights into a fresh context + buffer on the
 // CPU backend. Used on Mali-Vulkan, where the head runs on CPU while its encoder

--- a/parakeet-cpp/src/parakeet_ctc.cpp
+++ b/parakeet-cpp/src/parakeet_ctc.cpp
@@ -111,6 +111,15 @@ struct ParakeetCtcModel::Impl {
     // True when a GPU was detected but skipped as known-bad (Mali), so
     // backend_active fell back to CPU.
     bool                   gpu_unsupported = false;
+    // True when the active GPU backend is Mali-Vulkan: the Sortformer head is
+    // routed to CPU there (its transformer block 0 miscomputes to NaN on the
+    // Valhall driver) while the encoder + CTC/TDT/EOU heads stay on the Mali GPU.
+    bool                   sortformer_force_cpu = false;
+    // CPU-resident copies of the Sortformer head weights (Mali-Vulkan only), so
+    // the CPU head graph reads them from the CPU backend instead of
+    // dereferencing the GPU-resident originals.
+    ggml_context         * sortformer_cpu_ctx    = nullptr;
+    ggml_backend_buffer_t  sortformer_cpu_buffer = nullptr;
     ggml_backend_buffer_t  weights_buffer = nullptr;
     std::vector<std::unique_ptr<EncoderGraph>> encoder_graphs;
     static constexpr size_t k_encoder_graph_cache_max = 3;
@@ -121,6 +130,8 @@ struct ParakeetCtcModel::Impl {
         }
         encoder_graphs.clear();
         if (weights_buffer) ggml_backend_buffer_free(weights_buffer);
+        if (sortformer_cpu_buffer) ggml_backend_buffer_free(sortformer_cpu_buffer);
+        if (sortformer_cpu_ctx)    ggml_free(sortformer_cpu_ctx);
         if (ctx)            ggml_free(ctx);
         if (gguf)           gguf_free(gguf);
         if (backend_blas)   ggml_backend_free(backend_blas);
@@ -271,6 +282,16 @@ bool is_adreno_700plus(const char * s) {
     return v >= 700;
 }
 
+// True when a device name/description identifies an ARM Mali GPU ("Mali-G715",
+// "ARM Mali-G78", ...). Used to route the Sortformer head to CPU on Mali-Vulkan.
+bool desc_is_mali(const char * s) {
+    if (!s) return false;
+    std::string lowered(s);
+    std::transform(lowered.begin(), lowered.end(), lowered.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return lowered.find("mali") != std::string::npos;
+}
+
 const char * dev_reg_name(ggml_backend_dev_t dev) {
     if (!dev) return "";
     ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
@@ -295,8 +316,10 @@ const char * dev_reg_name(ggml_backend_dev_t dev) {
 // are dlopen()'d at runtime and are not linkable from libparakeet.
 // The registry walk reaches the same backends in both modes.
 ggml_backend_t init_gpu_backend(int n_gpu_layers, bool verbose,
-                                bool & out_skipped_unsupported_gpu) {
+                                bool & out_skipped_unsupported_gpu,
+                                bool & out_is_mali_vulkan) {
     out_skipped_unsupported_gpu = false;
+    out_is_mali_vulkan = false;
     if (n_gpu_layers <= 0) return nullptr;
 
     ensure_backends_loaded();
@@ -356,20 +379,11 @@ ggml_backend_t init_gpu_backend(int n_gpu_layers, bool verbose,
                 opencl_other.push_back({dev, name, desc, reg_name});
             }
         } else {
-            // ARM Mali (Valhall) Vulkan mis-computes every parakeet model (its
-            // narrow subgroup width breaks the ggml-vulkan shaders), so guard it
-            // by name as a known-bad backend (like the Adreno-6xx skip above) and
-            // route it to CPU.
-            const bool is_mali = (name && std::strstr(name, "Mali")) ||
-                                 (desc && std::strstr(desc, "Mali"));
-            if (is_mali) {
-                out_skipped_unsupported_gpu = true;
-                if (verbose) PARAKEET_LOG_INFO(
-                    "parakeet: Mali GPU '%s' mis-computes on Vulkan; using CPU\n",
-                    name ? name : (desc ? desc : "unknown"));
-            } else {
-                other_gpu.push_back({dev, name, desc, reg_name});
-            }
+            // Non-OpenCL GPUs (Vulkan, Metal, CUDA, Mali iGPU, Intel, ...). Mali
+            // (Valhall) Vulkan runs the encoder + CTC/TDT/EOU heads correctly;
+            // only its Sortformer head is routed to CPU (see sortformer_force_cpu),
+            // so unlike the Adreno-6xx skip above it is not guarded out here.
+            other_gpu.push_back({dev, name, desc, reg_name});
         }
     }
 
@@ -389,6 +403,8 @@ ggml_backend_t init_gpu_backend(int n_gpu_layers, bool verbose,
                 "parakeet: using %s backend (%s)\n",
                 c.reg_name && *c.reg_name ? c.reg_name : "GPU",
                 c.name ? c.name : (c.desc ? c.desc : "unknown"));
+            out_is_mali_vulkan = c.reg_name && std::strcmp(c.reg_name, "Vulkan") == 0
+                              && (desc_is_mali(c.desc) || desc_is_mali(c.name));
             return b;
         }
         return nullptr;
@@ -570,6 +586,68 @@ void set_opencl_cache_dir(const std::string & dir) {
 #endif
 }
 
+// Duplicate the Sortformer head weights into a fresh context + buffer on the
+// CPU backend. Used on Mali-Vulkan, where the head runs on CPU while its encoder
+// stays on the GPU: the head graph must read weights that live on the same
+// backend it executes on. Returns false on allocation failure.
+static bool build_sortformer_cpu_weights(ParakeetCtcModel::Impl * impl,
+                                         const SortformerWeights & src,
+                                         SortformerWeights & dst) {
+    dst = SortformerWeights{};
+    dst.transformer.resize(src.transformer.size());
+
+    struct Field { ggml_tensor * src; ggml_tensor ** dst; };
+    std::vector<Field> fields;
+    auto add = [&](ggml_tensor * s, ggml_tensor ** d) {
+        if (s) fields.push_back({ s, d });
+    };
+    add(src.encoder_proj_w, &dst.encoder_proj_w);
+    add(src.encoder_proj_b, &dst.encoder_proj_b);
+    for (size_t i = 0; i < src.transformer.size(); ++i) {
+        const SortformerTransformerBlock & sb = src.transformer[i];
+        SortformerTransformerBlock       & db = dst.transformer[i];
+        add(sb.attn_q_w,  &db.attn_q_w);   add(sb.attn_q_b,  &db.attn_q_b);
+        add(sb.attn_k_w,  &db.attn_k_w);   add(sb.attn_k_b,  &db.attn_k_b);
+        add(sb.attn_v_w,  &db.attn_v_w);   add(sb.attn_v_b,  &db.attn_v_b);
+        add(sb.attn_o_w,  &db.attn_o_w);   add(sb.attn_o_b,  &db.attn_o_b);
+        add(sb.ln1_w,     &db.ln1_w);      add(sb.ln1_b,     &db.ln1_b);
+        add(sb.ffn_in_w,  &db.ffn_in_w);   add(sb.ffn_in_b,  &db.ffn_in_b);
+        add(sb.ffn_out_w, &db.ffn_out_w);  add(sb.ffn_out_b, &db.ffn_out_b);
+        add(sb.ln2_w,     &db.ln2_w);      add(sb.ln2_b,     &db.ln2_b);
+    }
+    add(src.head_h2h_w, &dst.head_h2h_w);  add(src.head_h2h_b, &dst.head_h2h_b);
+    add(src.head_h2s_w, &dst.head_h2s_w);  add(src.head_h2s_b, &dst.head_h2s_b);
+
+    const size_t n = fields.size();
+    ggml_init_params p = {
+        /*mem_size=*/   ggml_tensor_overhead() * (n + 8),
+        /*mem_buffer=*/ nullptr,
+        /*no_alloc=*/   true,
+    };
+    impl->sortformer_cpu_ctx = ggml_init(p);
+    if (!impl->sortformer_cpu_ctx) return false;
+
+    for (Field & f : fields) {
+        ggml_tensor * t = ggml_new_tensor(impl->sortformer_cpu_ctx, f.src->type,
+                                          GGML_MAX_DIMS, f.src->ne);
+        ggml_set_name(t, ggml_get_name(f.src));
+        *f.dst = t;
+    }
+
+    impl->sortformer_cpu_buffer =
+        ggml_backend_alloc_ctx_tensors(impl->sortformer_cpu_ctx, impl->backend_cpu);
+    if (!impl->sortformer_cpu_buffer) return false;
+
+    std::vector<uint8_t> buf;
+    for (Field & f : fields) {
+        const size_t nb = ggml_nbytes(f.src);
+        buf.resize(nb);
+        ggml_backend_tensor_get(f.src, buf.data(), 0, nb);
+        ggml_backend_tensor_set(*f.dst, buf.data(), 0, nb);
+    }
+    return true;
+}
+
 int load_from_gguf(const std::string & gguf_path,
                    ParakeetCtcModel  & out_model,
                    int                 n_threads,
@@ -595,9 +673,20 @@ int load_from_gguf(const std::string & gguf_path,
     }
 
     bool skipped_unsupported_gpu = false;
-    impl->backend_gpu    = init_gpu_backend(n_gpu_layers, verbose, skipped_unsupported_gpu);
+    bool gpu_is_mali_vulkan = false;
+    impl->backend_gpu    = init_gpu_backend(n_gpu_layers, verbose, skipped_unsupported_gpu,
+                                            gpu_is_mali_vulkan);
     impl->backend_active = impl->backend_gpu ? impl->backend_gpu : impl->backend_cpu;
     impl->gpu_unsupported = skipped_unsupported_gpu && impl->backend_gpu == nullptr;
+    // On Mali-Vulkan the Sortformer head miscomputes (transformer block 0 -> NaN);
+    // route only that head to CPU while the encoder + CTC/TDT/EOU heads stay on GPU.
+    impl->sortformer_force_cpu =
+        gpu_is_mali_vulkan && impl->backend_active == impl->backend_gpu;
+    if (impl->sortformer_force_cpu && verbose) {
+        PARAKEET_LOG_INFO(
+            "parakeet: Sortformer diarization head -> CPU on Mali-Vulkan "
+            "(encoder + CTC/TDT/EOU stay on the GPU)\n");
+    }
 
     gguf_init_params params = { /*no_alloc=*/ true, &impl->ctx };
     impl->gguf = gguf_init_from_file(gguf_path.c_str(), params);
@@ -952,6 +1041,19 @@ int load_from_gguf(const std::string & gguf_path,
 
     out_model.impl = impl;
 
+    if (out_model.model_type == ParakeetModelType::SORTFORMER &&
+        impl->sortformer_force_cpu) {
+        if (!build_sortformer_cpu_weights(impl.get(), out_model.sortformer,
+                                          out_model.sortformer_cpu)) {
+            PARAKEET_LOG_ERROR(
+                "parakeet: failed to build CPU-resident Sortformer head weights\n");
+            return 15;
+        }
+        if (verbose) PARAKEET_LOG_INFO(
+            "parakeet: built CPU-resident Sortformer head weights "
+            "(diarization head runs on CPU; encoder stays on the Mali GPU)\n");
+    }
+
     if (verbose) {
         print_model_summary(out_model);
         const char * be = impl->backend_gpu
@@ -981,6 +1083,16 @@ std::string model_active_backend_name(const ParakeetCtcModel & m) {
 ggml_backend_t model_active_backend(ParakeetCtcModel & m) {
     if (!m.impl) return nullptr;
     return m.impl->backend_active;
+}
+
+ggml_backend_t model_sortformer_backend(ParakeetCtcModel & m) {
+    if (!m.impl) return nullptr;
+    return m.impl->sortformer_force_cpu ? m.impl->backend_cpu
+                                        : m.impl->backend_active;
+}
+
+bool model_sortformer_on_cpu(const ParakeetCtcModel & m) {
+    return m.impl && m.impl->sortformer_force_cpu;
 }
 
 void print_model_summary(const ParakeetCtcModel & m) {
@@ -1091,6 +1203,29 @@ ggml_tensor * subsampling_graph(ggml_context    * gctx,
     };
     const int conv_pad = causal_downsampling ? 0 : 1;
 
+    // Mali-Vulkan fix: the subsampler depthwise conv, lowered by hand like the
+    // portable ggml_conv_2d_dw. Upstream finishes the lowering with a broadcast
+    // ggml_mul_mat (kernel batched per-channel, broadcast over the input batch)
+    // that miscomputes to inf on Mali-G715/Valhall Vulkan. Express the identical
+    // per-channel contraction WITHOUT a mul_mat instead: an elementwise ggml_mul
+    // (kernel broadcast over the spatial + batch dims) then ggml_sum_rows over the
+    // KH*KW dim. The im2col stays F32 (ggml-vulkan SUM_ROWS needs an F32,
+    // contiguous-rows src0). Adreno/OpenCL and Apple/Metal compute the depthwise
+    // correctly already and stay bit-identical.
+    auto conv_2d_dw_f32 = [&](ggml_tensor * a, ggml_tensor * b,
+                              int s0, int s1, int p0, int p1, int d0, int d1) -> ggml_tensor * {
+        ggml_tensor * kf32 = a->type == GGML_TYPE_F32 ? a : ggml_cast(gctx, a, GGML_TYPE_F32);
+        ggml_tensor * new_a = ggml_reshape_4d(gctx, kf32, kf32->ne[0], kf32->ne[1], 1, kf32->ne[2] * kf32->ne[3]);
+        ggml_tensor * im2col = ggml_im2col(gctx, new_a,
+                                  ggml_reshape_4d(gctx, b, b->ne[0], b->ne[1], 1, b->ne[2] * b->ne[3]),
+                                  s0, s1, p0, p1, d0, d1, true, GGML_TYPE_F32);
+        ggml_tensor * new_b = ggml_reshape_4d(gctx, im2col, im2col->ne[0], im2col->ne[2] * im2col->ne[1], b->ne[2], b->ne[3]);
+        new_a = ggml_reshape_4d(gctx, new_a, new_a->ne[0] * new_a->ne[1], new_a->ne[2], new_a->ne[3], 1);
+        ggml_tensor * prod = ggml_mul(gctx, new_b, new_a);   // [KH*KW, OH*OW, C, N]: kernel bcast over spatial + batch
+        ggml_tensor * summed = ggml_sum_rows(gctx, prod);    // [1, OH*OW, C, N]: contract over the KH*KW dim
+        return ggml_reshape_4d(gctx, summed, im2col->ne[1], im2col->ne[2], b->ne[2], b->ne[3]);
+    };
+
     x = maybe_mask(x, mask_t0);
     x = causal_pad(x);
     x = ggml_conv_2d(gctx, S.conv0_w, x, 2, 2, conv_pad, conv_pad, 1, 1);
@@ -1100,7 +1235,7 @@ ggml_tensor * subsampling_graph(ggml_context    * gctx,
 
     x = maybe_mask(x, mask_t1);
     x = causal_pad(x);
-    x = ggml_conv_2d_dw(gctx, S.conv1_dw_w, x, 2, 2, conv_pad, conv_pad, 1, 1);
+    x = conv_2d_dw_f32(S.conv1_dw_w, x, 2, 2, conv_pad, conv_pad, 1, 1);
     x = ggml_add(gctx, x, conv_bias_bcast(gctx, S.conv1_dw_b, subsampling_channels));
     x = maybe_mask(x, mask_t2);
     x = ggml_conv_2d(gctx, S.conv1_pw_w, x, 1, 1, 0, 0, 1, 1);
@@ -1110,7 +1245,7 @@ ggml_tensor * subsampling_graph(ggml_context    * gctx,
 
     x = maybe_mask(x, mask_t2);
     x = causal_pad(x);
-    x = ggml_conv_2d_dw(gctx, S.conv2_dw_w, x, 2, 2, conv_pad, conv_pad, 1, 1);
+    x = conv_2d_dw_f32(S.conv2_dw_w, x, 2, 2, conv_pad, conv_pad, 1, 1);
     x = ggml_add(gctx, x, conv_bias_bcast(gctx, S.conv2_dw_b, subsampling_channels));
     x = maybe_mask(x, mask_t3);
     x = ggml_conv_2d(gctx, S.conv2_pw_w, x, 1, 1, 0, 0, 1, 1);

--- a/parakeet-cpp/src/parakeet_ctc.h
+++ b/parakeet-cpp/src/parakeet_ctc.h
@@ -290,6 +290,9 @@ struct ParakeetCtcModel {
     TdtWeights                tdt;
     EouWeights                eou;
     SortformerWeights         sortformer;
+    // CPU-resident copies of the Sortformer head weights; populated at load only
+    // on Mali-Vulkan, where the head runs on CPU while the encoder stays on GPU.
+    SortformerWeights         sortformer_cpu;
 
     ggml_tensor * mel_filterbank = nullptr;
     ggml_tensor * window         = nullptr;
@@ -334,6 +337,14 @@ bool        model_has_gpu_backend(const ParakeetCtcModel & m);
 bool        model_gpu_unsupported(const ParakeetCtcModel & m);
 std::string model_active_backend_name(const ParakeetCtcModel & m);
 ggml_backend_t model_active_backend(ParakeetCtcModel & m);
+
+// Backend for the Sortformer head: the active backend normally, but CPU on
+// Mali-Vulkan (its transformer block 0 miscomputes to NaN; encoder stays on GPU).
+ggml_backend_t model_sortformer_backend(ParakeetCtcModel & m);
+
+// True when the head is routed to CPU (Mali-Vulkan); the graph then reads the
+// CPU-resident weight copies (model.sortformer_cpu), not the GPU originals.
+bool model_sortformer_on_cpu(const ParakeetCtcModel & m);
 
 int run_subsampling(ParakeetCtcModel   & model,
                     const float        * mel,

--- a/parakeet-cpp/src/parakeet_ctc.h
+++ b/parakeet-cpp/src/parakeet_ctc.h
@@ -329,6 +329,9 @@ int load_from_gguf(const std::string & gguf_path,
 void print_model_summary(const ParakeetCtcModel & m);
 
 bool        model_has_gpu_backend(const ParakeetCtcModel & m);
+// True when a GPU was detected but routed to CPU as a known-bad backend (Mali).
+// Lets hosts treat the CPU backend as expected, not a GPU regression.
+bool        model_gpu_unsupported(const ParakeetCtcModel & m);
 std::string model_active_backend_name(const ParakeetCtcModel & m);
 ggml_backend_t model_active_backend(ParakeetCtcModel & m);
 

--- a/parakeet-cpp/src/parakeet_engine.cpp
+++ b/parakeet-cpp/src/parakeet_engine.cpp
@@ -227,6 +227,10 @@ std::string Engine::backend_name() const {
     return model_active_backend_name(pimpl_->model);
 }
 
+bool Engine::gpu_unsupported() const {
+    return model_gpu_unsupported(pimpl_->model);
+}
+
 void Engine::cancel() {
     pimpl_->cancel_flag.store(true);
 }

--- a/parakeet-cpp/src/parakeet_engine.cpp
+++ b/parakeet-cpp/src/parakeet_engine.cpp
@@ -593,15 +593,15 @@ static DiarizationResult engine_impl_diarize_helper(Engine::Impl & impl,
     sopts.threshold = opts.threshold;
     SortformerDiarizationResult dres;
 
-    ggml_backend_t active_backend = model_active_backend(impl.model);
-    if (!active_backend) {
-        throw std::runtime_error("diarize: no active ggml backend");
+    ggml_backend_t head_backend = model_sortformer_backend(impl.model);
+    if (!head_backend) {
+        throw std::runtime_error("diarize: no ggml backend for the diarization head");
     }
 
     int diarize_rc = sortformer_diarize_ggml(impl.model,
                                              enc_out.encoder_out.data(),
                                              enc_out.n_enc_frames, enc_out.d_model,
-                                             active_backend, sopts, dres);
+                                             head_backend, sopts, dres);
     if (diarize_rc != 0) {
         throw std::runtime_error("diarize: sortformer_diarize failed (rc=" +
                                  std::to_string(diarize_rc) + ")");
@@ -726,16 +726,16 @@ static DiarizationResult engine_impl_diarize_streaming_helper(
     s_opts.threshold = opts.threshold;
     SortformerDiarizationResult dres;
 
-    ggml_backend_t active_backend = model_active_backend(impl.model);
-    if (!active_backend) {
-        throw std::runtime_error("diarize_streaming: no active ggml backend");
+    ggml_backend_t head_backend = model_sortformer_backend(impl.model);
+    if (!head_backend) {
+        throw std::runtime_error("diarize_streaming: no ggml backend for the diarization head");
     }
 
     if (int rc_ = sortformer_aosc_step(impl.model,
                                        pre_encode.data(),
                                        n_pre_encode_frames, D,
                                        lc, rc, chunk_len_eff,
-                                       cache, cfg, active_backend, s_opts, dres);
+                                       cache, cfg, head_backend, s_opts, dres);
         rc_ != 0) {
         throw std::runtime_error("diarize_streaming: sortformer_aosc_step failed (rc=" +
                                  std::to_string(rc_) + ")");

--- a/parakeet-cpp/src/parakeet_sortformer.cpp
+++ b/parakeet-cpp/src/parakeet_sortformer.cpp
@@ -183,6 +183,7 @@ int sf_exec_graph(ggml_context * ctx, ggml_backend_t backend,
     speaker_probs.resize((size_t)T_enc * num_spks);
     ggml_backend_tensor_get(x_out, speaker_probs.data(), 0,
                             speaker_probs.size() * sizeof(float));
+
     ggml_gallocr_free(alloc);
     return 0;
 }
@@ -645,9 +646,14 @@ int sortformer_diarize_ggml(const ParakeetCtcModel & model,
     ggml_context * ctx = ggml_init(gp);
     if (!ctx) return -1;
 
-    // 2. Build graph
+    // 2. Build graph. On Mali-Vulkan the head runs on CPU while its encoder
+    // stays on the GPU; read the CPU-resident head weights there so the graph's
+    // weights match its backend (GPU originals would segfault a CPU matmul).
+    const SortformerWeights & sw = model_sortformer_on_cpu(model)
+                                       ? model.sortformer_cpu
+                                       : model.sortformer;
     ggml_tensor * x_in  = nullptr;
-    ggml_tensor * x_out = sf_build_graph(ctx, model.sortformer,
+    ggml_tensor * x_out = sf_build_graph(ctx, sw,
                                          n_layers, n_heads, head_dim,
                                          tf_d, D_in, T_enc, &x_in);
 

--- a/parakeet-cpp/src/parakeet_tdt.cpp
+++ b/parakeet-cpp/src/parakeet_tdt.cpp
@@ -269,10 +269,10 @@ LstmBodyOuts build_lstm_body(TdtRuntimeWeights & rt,
 // readback is ~17 us); on a discrete GPU PCIe bus it's an
 // order-of-magnitude saving per emission step (~250 / call).
 struct JointBodyOuts {
-    ggml_tensor * token_argmax;  // i32[1], over logits[0 : V_plus_1]
-    ggml_tensor * dur_argmax;    // i32[1], over logits[V_plus_1 : V_plus_1 + num_durations]
+    ggml_tensor * token_out;  // argmax i32[1] (argmax_on_gpu) OR token logits f32[V_plus_1]
+    ggml_tensor * dur_out;    // argmax i32[1] (argmax_on_gpu) OR dur logits f32[num_durations]
 };
-JointBodyOuts build_joint_body(const TdtRuntimeWeights & rt,
+JointBodyOuts build_joint_body(TdtRuntimeWeights & rt,
                                ggml_context * gctx,
                                ggml_tensor * pred_src,
                                ggml_tensor * frame_idx_in) {
@@ -314,9 +314,20 @@ JointBodyOuts build_joint_body(const TdtRuntimeWeights & rt,
     tok_logits = ggml_cont(gctx, tok_logits);
     dur_logits = ggml_cont(gctx, dur_logits);
 
+    // ggml-opencl has no ARGMAX kernel (graph_compute would abort), so gate the
+    // on-device argmax on backend support and fall back to a host argmax of the
+    // logit slices otherwise. tok_am is unused on that path (never expanded).
+    ggml_tensor * tok_am = ggml_argmax(gctx, tok_logits);  // i32[1]
+    rt.argmax_on_gpu = ggml_backend_supports_op(rt.backend, tok_am);
+
     JointBodyOuts outs{};
-    outs.token_argmax = ggml_argmax(gctx, tok_logits);  // i32[1]
-    outs.dur_argmax   = ggml_argmax(gctx, dur_logits);  // i32[1]
+    if (rt.argmax_on_gpu) {
+        outs.token_out = tok_am;
+        outs.dur_out   = ggml_argmax(gctx, dur_logits);  // i32[1]
+    } else {
+        outs.token_out = tok_logits;
+        outs.dur_out   = dur_logits;
+    }
     return outs;
 }
 
@@ -360,10 +371,10 @@ void build_joint_graph(TdtRuntimeWeights & rt) {
     ggml_set_input(rt.joint_frame_idx_in);
 
     JointBodyOuts outs = build_joint_body(rt, gctx, rt.pred_persist, rt.joint_frame_idx_in);
-    rt.joint_token_out = outs.token_argmax;
-    rt.joint_dur_out   = outs.dur_argmax;
-    ggml_set_name(rt.joint_token_out, "joint.token_argmax");
-    ggml_set_name(rt.joint_dur_out,   "joint.dur_argmax");
+    rt.joint_token_out = outs.token_out;
+    rt.joint_dur_out   = outs.dur_out;
+    ggml_set_name(rt.joint_token_out, rt.argmax_on_gpu ? "joint.token_argmax" : "joint.token_logits");
+    ggml_set_name(rt.joint_dur_out,   rt.argmax_on_gpu ? "joint.dur_argmax"   : "joint.dur_logits");
     ggml_set_output(rt.joint_token_out);
     ggml_set_output(rt.joint_dur_out);
 
@@ -399,10 +410,10 @@ void build_lstm_joint_graph(TdtRuntimeWeights & rt) {
     // Use the pred_cpy node (not pred_persist directly) so the joint mat_muls
     // depend on the LSTM update finishing first.
     JointBodyOuts joint_outs = build_joint_body(rt, gctx, lstm_outs.pred_cpy, rt.lj_frame_idx_in);
-    rt.lj_token_out = joint_outs.token_argmax;
-    rt.lj_dur_out   = joint_outs.dur_argmax;
-    ggml_set_name(rt.lj_token_out, "lstm_joint.token_argmax");
-    ggml_set_name(rt.lj_dur_out,   "lstm_joint.dur_argmax");
+    rt.lj_token_out = joint_outs.token_out;
+    rt.lj_dur_out   = joint_outs.dur_out;
+    ggml_set_name(rt.lj_token_out, rt.argmax_on_gpu ? "lstm_joint.token_argmax" : "lstm_joint.token_logits");
+    ggml_set_name(rt.lj_dur_out,   rt.argmax_on_gpu ? "lstm_joint.dur_argmax"   : "lstm_joint.dur_logits");
     ggml_set_output(rt.lj_token_out);
     ggml_set_output(rt.lj_dur_out);
     // Mark the LSTM cpy nodes as outputs too so gallocr keeps them alive
@@ -619,6 +630,15 @@ int tdt_prepare_runtime(const ParakeetCtcModel & model, TdtRuntimeWeights & W) {
     // because of native quantised matmul and faster argmax / large gemvs.
     W.use_graphs = !backend_is_cpu(W.backend);
 
+    // ggml-opencl drops the in-place ggml_cpy writes that update the TDT LSTM
+    // persistent state (h/c/pred), so the state never advances and the decode
+    // emits one constant token per frame. Run the per-step decode on the host on
+    // OpenCL; the encoder still runs on the GPU. (EOU/Sortformer don't use this
+    // persistent-state pattern and stay on the GPU.)
+    if (W.use_graphs && std::strcmp(backend_reg_name(W.backend), "OpenCL") == 0) {
+        W.use_graphs = false;
+    }
+
     if (!W.use_graphs) {
         // ---- CPU fallback: dequantise weights to host f32 ----
         dequantize_to_f32(model.tdt.predict_embed, W.embed);
@@ -732,6 +752,30 @@ bool run_lstm_init_step(TdtRuntimeWeights & rt, int token_id) {
     return true;
 }
 
+// Read the joint token/dur outputs into host ints: i32 argmax indices when
+// argmax_on_gpu, else the raw f32 logit slices (ggml-opencl) argmaxed on host.
+// thread_local scratch keeps the per-step readback allocation-free.
+void resolve_joint_step(TdtRuntimeWeights & rt,
+                        ggml_tensor * tok_t, ggml_tensor * dur_t,
+                        int * tok_out, int * dur_out) {
+    if (rt.argmax_on_gpu) {
+        int32_t tok_val = 0, dur_val = 0;
+        ggml_backend_tensor_get(tok_t, &tok_val, 0, sizeof(int32_t));
+        ggml_backend_tensor_get(dur_t, &dur_val, 0, sizeof(int32_t));
+        *tok_out = (int) tok_val;
+        *dur_out = (int) dur_val;
+        return;
+    }
+    static thread_local std::vector<float> tok_logits;
+    static thread_local std::vector<float> dur_logits;
+    tok_logits.resize((size_t) rt.V_plus_1);
+    dur_logits.resize((size_t) rt.num_durations);
+    ggml_backend_tensor_get(tok_t, tok_logits.data(), 0, (size_t) rt.V_plus_1 * sizeof(float));
+    ggml_backend_tensor_get(dur_t, dur_logits.data(), 0, (size_t) rt.num_durations * sizeof(float));
+    *tok_out = argmax_f32(tok_logits.data(), rt.V_plus_1);
+    *dur_out = argmax_f32(dur_logits.data(), rt.num_durations);
+}
+
 // Joint-only step (used after a blank emission). pred_persist is unchanged
 // from the previous step; only enc_proj_persist[frame_idx] varies.  The
 // graph runs token + duration argmax on-device, so the host reads
@@ -750,11 +794,7 @@ bool run_joint_step(TdtRuntimeWeights & rt,
         return false;
     }
 
-    int32_t tok_val = 0, dur_val = 0;
-    ggml_backend_tensor_get(rt.joint_token_out, &tok_val, 0, sizeof(int32_t));
-    ggml_backend_tensor_get(rt.joint_dur_out,   &dur_val, 0, sizeof(int32_t));
-    *tok_out = (int) tok_val;
-    *dur_out = (int) dur_val;
+    resolve_joint_step(rt, rt.joint_token_out, rt.joint_dur_out, tok_out, dur_out);
     return true;
 }
 
@@ -777,11 +817,7 @@ bool run_lstm_joint_step(TdtRuntimeWeights & rt,
         return false;
     }
 
-    int32_t tok_val = 0, dur_val = 0;
-    ggml_backend_tensor_get(rt.lj_token_out, &tok_val, 0, sizeof(int32_t));
-    ggml_backend_tensor_get(rt.lj_dur_out,   &dur_val, 0, sizeof(int32_t));
-    *tok_out = (int) tok_val;
-    *dur_out = (int) dur_val;
+    resolve_joint_step(rt, rt.lj_token_out, rt.lj_dur_out, tok_out, dur_out);
     return true;
 }
 

--- a/parakeet-cpp/src/parakeet_tdt.h
+++ b/parakeet-cpp/src/parakeet_tdt.h
@@ -61,6 +61,9 @@ struct TdtRuntimeWeights {
     ggml_backend_t     backend = nullptr;
     int                n_threads = 0;
     bool               use_graphs = false;
+    // false on ggml-opencl (no ARGMAX kernel): the joint graph emits raw logits
+    // for the host to argmax; true elsewhere keeps the argmax on-device.
+    bool               argmax_on_gpu = true;
 
     // ---- CPU-fallback host weights (populated only when !use_graphs) ----
     std::vector<float>             embed;
@@ -111,8 +114,8 @@ struct TdtRuntimeWeights {
     ggml_cgraph *  g_joint     = nullptr;
     ggml_gallocr_t alloc_joint = nullptr;
     ggml_tensor *  joint_frame_idx_in = nullptr;  // i32[1]
-    ggml_tensor *  joint_token_out    = nullptr;  // i32[1] — token argmax
-    ggml_tensor *  joint_dur_out      = nullptr;  // i32[1] — duration argmax
+    ggml_tensor *  joint_token_out    = nullptr;  // i32 argmax, or f32 token logits when !argmax_on_gpu
+    ggml_tensor *  joint_dur_out      = nullptr;  // i32 argmax, or f32 dur logits when !argmax_on_gpu
 
     // (3) Fused LSTM + joint graph: used after a non-blank emission.
     //     LSTM updates h/c/pred from the last emitted token, then joint
@@ -123,8 +126,8 @@ struct TdtRuntimeWeights {
     ggml_gallocr_t alloc_lstm_joint = nullptr;
     ggml_tensor *  lj_token_in        = nullptr;  // i32[1]
     ggml_tensor *  lj_frame_idx_in    = nullptr;  // i32[1]
-    ggml_tensor *  lj_token_out       = nullptr;  // i32[1] — token argmax
-    ggml_tensor *  lj_dur_out         = nullptr;  // i32[1] — duration argmax
+    ggml_tensor *  lj_token_out       = nullptr;  // i32 argmax, or f32 token logits when !argmax_on_gpu
+    ggml_tensor *  lj_dur_out         = nullptr;  // i32 argmax, or f32 dur logits when !argmax_on_gpu
 
     struct EncProjGraph {
         // Each cached graph owns its own ggml_context for the cgraph + tensor


### PR DESCRIPTION
Replaces the blanket Mali-Vulkan -> CPU guard with two surgical fixes so Parakeet runs on the Mali GPU.

## Encoder
The subsampler depthwise conv lowered to a broadcast `ggml_mul_mat` that deterministically miscomputes to `inf` on Mali-G715/Valhall Vulkan. Reformulated as an elementwise `ggml_mul` + `ggml_sum_rows` (F32 im2col), which is mathematically identical and keeps Adreno/OpenCL and Apple/Metal bit-identical. CTC/TDT/EOU are now correct on the Mali GPU.

## Sortformer diarization head
Its transformer block 0 miscomputes to NaN on Valhall, so route **only** that head to the CPU backend (encoder stays on the GPU). The model runs a single-backend graph with no `ggml_backend_sched`, so the head's q4_0 weights must share a backend with its compute — `build_sortformer_cpu_weights()` makes CPU-resident copies at load and the head reads them when it runs on CPU. Covers non-streaming diarize + streaming AOSC.

Mali detection = Vulkan backend + device name/description contains "Mali".

## Validation
- **Device-confirmed** on Pixel 9 / Mali-G715: 19/19, `crashed:false`, no SIGSEGV in the head matmul; Samsung S25 / Adreno 19/19 unaffected.
- Local Metal pre-flight: gpu-smoke 4/4 (the Mali routing is inert on non-Mali backends).

This branch also carries the Adreno-OpenCL TDT host-decode fix that accumulated during the QVAC-20556 Android-GPU campaign; the interim Mali->CPU guard it introduced is removed again by the encoder/head fixes above.
